### PR TITLE
Fix project not compiling on OS X 10.11.6.

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -18,6 +18,14 @@
     #include <OpenGL/gl.h>
     #include <OpenGL/glext.h>
     #include <AGL/agl.h>
+/*
+ * In compatibility mode, Mac OS X only supports OpenGL 2 (no VAO), but it does 
+ * support the Apple-specific VAO extension which is older and in all relevant 
+ * parts 100% compatible. So use those functions instead.
+ */
+#define glBindVertexArray glBindVertexArrayAPPLE
+#define glGenVertexArrays glGenVertexArraysAPPLE
+#define glDeleteVertexArrays glDeleteVertexArraysAPPLE
 #elif __EMSCRIPTEN__
     #define MOBILE 1
     #include <emscripten.h>


### PR DESCRIPTION
As the comment says: In Compatibility mode (used by including gl.h instead of gl3.h), OS X only supports OpenGL 2 with some extensions. VAOs, which are an OpenGL 3 feature, are not available under their OpenGL 3 name. Instead they are exposed through an Apple-specific extension that works identically in all respects that matter. With this, it is possible to build and run the program without any trouble.