### PR TITLE
Bug Fix: Jump Forward.

### DIFF
--- a/src/lara.h
+++ b/src/lara.h
@@ -1429,11 +1429,13 @@ struct Lara : Character {
         // ready to jump
         if (state == STATE_COMPRESS) {
             switch (input & (RIGHT | LEFT | FORTH | BACK)) {
-                case RIGHT  : return STATE_RIGHT_JUMP;
-                case LEFT   : return STATE_LEFT_JUMP;
-                case FORTH  : return STATE_FORWARD_JUMP;
-                case BACK   : return STATE_BACK_JUMP;
-                default     : return STATE_UP_JUMP;
+                case RIGHT         : return STATE_RIGHT_JUMP;
+                case LEFT          : return STATE_LEFT_JUMP;
+                case FORTH | LEFT  :
+                case FORTH | RIGHT :
+                case FORTH         : return STATE_FORWARD_JUMP;
+                case BACK          : return STATE_BACK_JUMP;
+                default            : return STATE_UP_JUMP;
             }
         }
 


### PR DESCRIPTION
In the original game, pressing Jump + (Left || Right) should allow Lara
to jump forward too. In OpenLara this is not possible as the input code
only checks if forward flag is set when pressed. Not forward + (Left ||
Right) resuling in Lara not being able to jump forward and only straight
up in these cases.