### PR TITLE
android: minimp3: Avoid redefinition of datatypes

### DIFF
--- a/src/libs/minimp3/libc.h
+++ b/src/libs/minimp3/libc.h
@@ -44,6 +44,8 @@
     #ifdef _MSC_VER
         typedef unsigned __int64 uint64_t;
         typedef   signed __int64  int64_t;
+    #elif defined(__x86_64__) && defined(__linux__)
+        #include <sys/types.h>
     #else
         typedef unsigned long long uint64_t;
         typedef   signed long long  int64_t;

--- a/src/platform/android/app/src/main/java/org/xproger/openlara/MainActivity.java
+++ b/src/platform/android/app/src/main/java/org/xproger/openlara/MainActivity.java
@@ -194,10 +194,22 @@ class Sound {
         int rate = 44100;
         int size = AudioTrack.getMinBufferSize(rate, AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_16BIT);
         //System.out.println(String.format("sound buffer size: %d", bufSize));
-        buffer = new short [size / 2];
-        audioTrack = new AudioTrack(AudioManager.STREAM_MUSIC, 44100, AudioFormat.CHANNEL_OUT_STEREO,
-                                    AudioFormat.ENCODING_PCM_16BIT, size, AudioTrack.MODE_STREAM);
-        audioTrack.play();
+        buffer = new short[size / 2];
+
+        try {
+            audioTrack = new AudioTrack(AudioManager.STREAM_MUSIC, 44100, AudioFormat.CHANNEL_OUT_STEREO,
+                    AudioFormat.ENCODING_PCM_16BIT, size, AudioTrack.MODE_STREAM);
+        }catch (IllegalArgumentException e){
+            System.out.println("Error: buffer size is zero");
+            return;
+        }
+
+        try {
+            audioTrack.play();
+        }catch (NullPointerException e){
+            System.out.println("Error: audioTrack null pointer on start()");
+            return;
+        }
 
         new Thread( new Runnable() {
             public void run() {
@@ -220,17 +232,29 @@ class Sound {
     }
 
     void stop() {
-        audioTrack.flush();
-        audioTrack.stop();
-        audioTrack.release();
+        try {
+            audioTrack.flush();
+            audioTrack.stop();
+            audioTrack.release();
+        }catch (NullPointerException e){
+            System.out.println("Error: audioTrack null pointer on stop()");
+        }
     }
 
     void play() {
-        audioTrack.play();
+        try {
+            audioTrack.play();
+        }catch (NullPointerException e){
+            System.out.println("Error: audioTrack null pointer on play()");
+        }
     }
 
     void pause() {
-        audioTrack.pause();
+        try {
+            audioTrack.pause();
+        }catch (NullPointerException e){
+            System.out.println("Error: audioTrack null pointer on pause()");
+        };
     }
 }
 


### PR DESCRIPTION
Under Linux OS there's no need to redefine int64_t as a data type
still including sys/types.h to take care of any missing data types.

The following compilation errors are thrown if int64_t is defined:

Error:(50, 36) error: typedef redefinition with different types
 ('unsigned long long' vs '__uint64_t' (aka 'unsigned long'))
Error:(51, 37) error: typedef redefinition with different types
 ('long long' vs '__int64_t' (aka 'long'))

Issue: https://github.com/XProger/OpenLara/issues/67

Signed-off-by: Carlos Santa <santa.cm@gmail.com>