### PR TITLE
Fix lack of water effects when using an AMD graphics card under Linux.

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -410,6 +410,9 @@ struct WaterCache {
             caustics = new Texture(512, 512, Texture::RGB16, false);
             mask     = new Texture(w, h, Texture::RGB16, false, m, false);
             delete[] m;
+            
+            Core::setTarget(data[0], true);
+            Core::setTarget(NULL);
 
             blank = false;
 
@@ -571,7 +574,7 @@ struct WaterCache {
         while (item.timer >= SIMULATE_TIMESTEP) {
         // water step
             item.data[0]->bind(sDiffuse);
-            Core::setTarget(item.data[1], 0, true);
+            Core::setTarget(item.data[1], true);
             Core::setViewport(0, 0, int(item.size.x * DETAIL * 2.0f + 0.5f), int(item.size.z * DETAIL * 2.0f + 0.5f));
             game->getMesh()->renderQuad();
             Core::invalidateTarget(false, true);


### PR DESCRIPTION
There were two instances in the code in which the water texture was left uninitialized and, because this texture is used as the starting point for the water effects, this caused the caustics and reflections not to show at all. The result was a fully transparent water, and ocasionally some weird graphical glitches.

Apparently this only happens with the open source AMD driver on Linux. I was able to check that this bug does not happen with an Intel GPU or when using the Mesa software rasterizer (llvmpipe). According to the OpenGL specification, applying an uninitialized texture to a primitive is undefined, but I guess that for some reason the Intel and llvmpipe drivers automatically zero the texture memory, while the AMD driver does not.