### PR TITLE
Linux fixes

### DIFF
--- a/src/platform/nix/main.cpp
+++ b/src/platform/nix/main.cpp
@@ -48,7 +48,7 @@ void sndInit() {
     };
 
     static const pa_buffer_attr attr = {
-        .maxlength  = SND_DATA_SIZE * 2,
+        .maxlength  = SND_DATA_SIZE * 4,
         .tlength    = 0xFFFFFFFF,
         .prebuf     = 0xFFFFFFFF,
         .minreq     = SND_DATA_SIZE,

--- a/src/platform/nix/main.cpp
+++ b/src/platform/nix/main.cpp
@@ -169,6 +169,10 @@ int main(int argc, char **argv) {
         GLX_RGBA,
         GLX_DOUBLEBUFFER,
         GLX_DEPTH_SIZE, 24,
+        GLX_RED_SIZE, 8,
+        GLX_GREEN_SIZE, 8,
+        GLX_BLUE_SIZE, 8,
+        GLX_ALPHA_SIZE, 8,
         0
     };
 


### PR DESCRIPTION
Two small fixes for the Linux version of OpenLara.

First, I changed the GLX visual attributes so that they match the values used in the other platforms. This fixes an issue with water refractions. They were almost absent before, and now they are correctly rendered.

The second issue was that I was consistently getting crackling sound, and I guess that buffer underruns were the cause of this. So I raised the maximum length of the buffer and this seems to have fixed the problem.