### PR TITLE
plumbered a kmsdrm rendering context

### DIFF
--- a/src/platform/kmsdrm/Makefile
+++ b/src/platform/kmsdrm/Makefile
@@ -1,0 +1,28 @@
+OBJS=OpenLara.o
+BIN=../../../bin/OpenLara.bin
+
+CFLAGS+=-D__RPI__
+LDFLAGS+= -lGLESv2 -lEGL -lpthread -lrt -lm
+
+INCLUDES+= -I./ 
+
+all: $(BIN) $(LIB)
+
+%.o: %.c
+	@rm -f $@ 
+	$(CC) $(CFLAGS) $(INCLUDES) -g -c $< -o $@ -Wno-deprecated-declarations
+
+%.o: %.cpp
+	@rm -f $@ 
+	$(CXX) $(CFLAGS) $(INCLUDES) -g -c $< -o $@ -Wno-deprecated-declarations
+
+%.bin: $(OBJS)
+	$(CC) -o $@ -Wl,--whole-archive $(OBJS) $(LDFLAGS) -Wl,--no-whole-archive -rdynamic
+
+%.a: $(OBJS)
+	$(AR) r $@ $^
+
+clean:
+	for i in $(OBJS); do (if test -e "$$i"; then ( rm $$i ); fi ); done
+	@rm -f $(BIN) $(LIB)
+

--- a/src/platform/kmsdrm/build.sh
+++ b/src/platform/kmsdrm/build.sh
@@ -1,0 +1,3 @@
+set -e
+g++ -std=c++11 -O0 -ggdb -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections -DNDEBUG -D__RPI__ main.cpp ../../libs/stb_vorbis/stb_vorbis.c ../../libs/minimp3/minimp3.cpp ../../libs/tinf/tinflate.c ./context.c -I../../ -I/usr/include/drm -o../../../bin/OpenLara -lm -lrt -lpthread -lasound -ludev -lSDL2 -lEGL -lGLESv2 -ldrm -lgbm
+#strip ../../../bin/OpenLara --strip-all --remove-section=.comment --remove-section=.note

--- a/src/platform/kmsdrm/context.c
+++ b/src/platform/kmsdrm/context.c
@@ -1,0 +1,307 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <unistd.h>
+
+#include <GLES2/gl2.h>
+#include <EGL/egl.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+#include <gbm.h>
+#include <fcntl.h>
+
+struct drm_fb {
+	struct gbm_bo *bo;
+	uint32_t fb_id;
+};
+
+struct gbm_device {
+	struct gbm_device *dev;
+	struct gbm_surface *surface;
+};
+
+struct drm_device{
+	int fd;
+	drmModeModeInfo *mode;
+	uint32_t crtc_id;
+	uint32_t connector_id;
+
+	drmModeCrtcPtr orig_crtc;
+};
+
+struct gbm_device gbm;
+struct drm_device drm;
+struct gbm_bo *bo;
+struct drm_fb *fb;
+
+drmEventContext eventContext;
+
+extern EGLDisplay display;
+extern EGLConfig config;
+extern EGLContext context;
+extern EGLSurface surface;
+
+void drmPageFlipHandler(int fd, uint frame, uint sec, uint usec, void *data) {
+	int *waiting_for_flip = (int *)data;
+	*waiting_for_flip = 0;
+}
+
+struct drm_fb *drmFBGetFromBO(struct gbm_bo *bo) {
+	struct drm_fb *fb = (struct drm_fb*)gbm_bo_get_user_data(bo);
+	uint32_t width, height, stride, handle;
+
+	if (fb) {
+		return fb;
+	}
+	
+	fb = (struct drm_fb *)calloc(1, sizeof *fb);
+	fb->bo = bo;
+
+	width = gbm_bo_get_width(bo);
+	height = gbm_bo_get_height(bo);
+	stride = gbm_bo_get_stride(bo);
+	handle = gbm_bo_get_handle(bo).u32;
+
+	if (drmModeAddFB(drm.fd, width, height, 24, 32, stride, handle, &fb->fb_id)) {
+		printf("Could not add drm framebuffer\n");
+		free(fb);
+		return NULL;
+	}
+
+	// We used to pass the destroy callback function here. Now it's done manually in deinitEGL()
+	gbm_bo_set_user_data(bo, fb, NULL);
+	return fb;
+}
+
+void drmPageFlip(void) {
+	int waiting_for_flip = 1;
+	fd_set fds;
+
+	struct gbm_bo *next_bo = gbm_surface_lock_front_buffer(gbm.surface);
+	fb = drmFBGetFromBO(next_bo);
+
+	if (drmModePageFlip(drm.fd, drm.crtc_id, fb->fb_id, DRM_MODE_PAGE_FLIP_EVENT, &waiting_for_flip)) {
+		printf ("Failed to queue pageflip\n");
+		return;
+	}
+
+	while (waiting_for_flip) {
+		FD_ZERO(&fds);
+		FD_SET(0, &fds);
+		FD_SET(drm.fd, &fds);
+		select(drm.fd+1, &fds, NULL, NULL, NULL);
+		drmHandleEvent(drm.fd, &eventContext);
+	}
+	
+	// release last buffer to render on again
+	gbm_surface_release_buffer(gbm.surface, bo);
+	bo = next_bo;
+}
+
+void swap_window () {
+	    eglSwapBuffers(display, surface);
+            drmPageFlip();
+}
+
+bool initDRM(void) {
+	// In plain C, we can just init _eventContext at declare time, but it's now allowed in C++
+	eventContext.version = DRM_EVENT_CONTEXT_VERSION;
+	eventContext.page_flip_handler = drmPageFlipHandler;
+
+	drmModeConnector *connector;
+	drmModeEncoder *encoder;
+	uint i, area;
+
+	drm.fd = open("/dev/dri/card0", O_RDWR);
+
+	if (drm.fd < 0) {
+		printf ("could not open drm device\n");
+		return false;
+	}
+
+	drmModeRes *resources = drmModeGetResources(drm.fd);
+	if (!resources) {
+		printf ("drmModeGetResources failed\n");
+		return false;
+	}
+
+	// find a connected connector
+	for (i = 0; i < (uint)resources->count_connectors; i++) {
+		connector = drmModeGetConnector(drm.fd, resources->connectors[i]);
+		if (connector->connection == DRM_MODE_CONNECTED) {
+			// it's connected, let's use this!
+			break;
+		}
+		drmModeFreeConnector(connector);
+		connector = NULL;
+	}
+
+	if (!connector) {
+		// we could be fancy and listen for hotplug events and wait for
+		// a connector..
+		printf ("no connected connector found\n");
+		return false;
+	}
+	// find highest resolution mode
+	for (i = 0, area = 0; i < (uint)connector->count_modes; i++) {
+		drmModeModeInfo *current_mode = &connector->modes[i];
+		uint current_area = current_mode->hdisplay * current_mode->vdisplay;
+		if (current_area > area) {
+			drm.mode = current_mode;
+			area = current_area;
+		}
+	}
+
+	if (!drm.mode) {
+		printf ("could not find mode\n");
+		return false;
+	}
+
+	// find encoder
+	for (i = 0; i < (uint)resources->count_encoders; i++) {
+		encoder = drmModeGetEncoder(drm.fd, resources->encoders[i]);
+		if (encoder->encoder_id == connector->encoder_id)
+			break;
+		drmModeFreeEncoder(encoder);
+		encoder = NULL;
+	}
+
+	if (!encoder) {
+		printf ("no encoder found\n");
+		return false;
+	}
+
+	drm.crtc_id = encoder->crtc_id;
+	drm.connector_id = connector->connector_id;
+
+	// backup original crtc so we can restore the original video mode on exit.
+	drm.orig_crtc = drmModeGetCrtc(drm.fd, encoder->crtc_id);
+
+	return true;
+}
+
+bool initGBM() {
+	gbm.dev = gbm_create_device(drm.fd);
+
+	gbm.surface = gbm_surface_create(gbm.dev,
+			drm.mode->hdisplay, drm.mode->vdisplay,
+			GBM_FORMAT_XRGB8888,
+			GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING);
+
+	if (!gbm.surface) {
+		printf ("failed to create gbm surface\n");
+		return -1;
+	}
+	
+	return true;
+}
+
+extern int physical_width;
+extern int physical_height;
+
+void init_window () {
+	if (!initDRM()) {
+		printf ("failed to initialize DRM\n");
+		return;
+	}
+
+	// Create the GBM surface, which contains several buffers. A GBM surface is an "abstraction".
+	if (!initGBM()) {
+		printf ("failed to initialize GBM\n");
+		return;
+	}
+}
+
+
+void init_egl() {
+
+	static const EGLint attributeList[] = {
+		EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+        	EGL_SURFACE_TYPE,    EGL_WINDOW_BIT,
+        	EGL_BLUE_SIZE,       8,
+		EGL_GREEN_SIZE,      8,
+		EGL_RED_SIZE,        8,
+		EGL_ALPHA_SIZE,      8,
+		EGL_NONE
+	};
+	
+	// create an EGL rendering context
+	static const EGLint contextAttributes[] = {
+	    EGL_CONTEXT_CLIENT_VERSION, 2,
+	    EGL_NONE
+	};
+
+	EGLint numConfig;
+	
+	display = eglGetDisplay((NativeDisplayType)gbm.dev);
+	assert(display != EGL_NO_DISPLAY);
+
+	// initialize the EGL display connection
+	EGLBoolean result = eglInitialize(display, NULL, NULL);
+	assert(EGL_FALSE != result);
+    
+	// get an appropriate EGL frame buffer configuration
+	result = eglChooseConfig(display, attributeList, &config, 1, &numConfig);
+	assert(EGL_FALSE != result);
+   
+	context = eglCreateContext(display, config, EGL_NO_CONTEXT, contextAttributes);
+	assert(context != EGL_NO_CONTEXT);
+
+        surface = eglCreateWindowSurface(display, config, (EGLNativeWindowType)gbm.surface, NULL);
+	assert(surface != EGL_NO_SURFACE);
+
+	// connect the context to the surface
+	result = eglMakeCurrent(display, surface, surface, context);
+	assert(EGL_FALSE != result);
+
+	if (eglSwapBuffers(display, surface) != EGL_TRUE) {
+		printf("eglSwapBuffers() failed\n");
+	}
+	
+	// NEVER call this without having called eglSwapBuffers before: it will segfault badly.
+        // THIS is why you need to call eglSwapBuffers before calling drmModeSetCrtc: because you need
+	// to call eglSwapBuffers so you can call gbm_surface_lock_front_buffer so you can call
+        // drmModeSetCrtc on the buffer you get.
+        bo = gbm_surface_lock_front_buffer(gbm.surface);
+        fb = drmFBGetFromBO(bo);
+
+        // set mode physical video mode
+        if (drmModeSetCrtc(drm.fd, drm.crtc_id, fb->fb_id, 0, 0, &drm.connector_id, 1, drm.mode)) {
+                printf ("failed to set mode\n");
+                return;
+	}
+
+	physical_width = drm.mode->hdisplay;
+	physical_height = drm.mode->vdisplay;
+
+	printf ("EGL init succesfull\n");
+}
+
+void deinit_egl() {
+	// Release context resources
+	eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+	eglDestroySurface(display, surface);
+	eglDestroyContext(display, context);
+	eglTerminate(display);
+}
+
+void deinit_window () {
+	// Restore the original videomode/connector/scanoutbuffer combination (the original CRTC, that is). 
+	drmModeSetCrtc(drm.fd, drm.orig_crtc->crtc_id, drm.orig_crtc->buffer_id,
+		drm.orig_crtc->x, drm.orig_crtc->y,
+		&drm.connector_id, 1, &drm.orig_crtc->mode);	
+
+	if (fb->fb_id) {
+		drmModeRmFB(drm.fd, fb->fb_id);
+	}
+
+	// If we want to re-create the context in the same program, we need to de-init
+	// gbm before we init it again.
+	gbm_surface_destroy(gbm.surface);
+	gbm_device_destroy(gbm.dev);
+
+	free(fb);
+
+	close(drm.fd);
+}

--- a/src/platform/kmsdrm/context.h
+++ b/src/platform/kmsdrm/context.h
@@ -1,0 +1,15 @@
+#include <EGL/egl.h>
+
+int physical_width;
+int physical_height;
+
+EGLDisplay display;
+EGLConfig config;
+EGLContext context;
+EGLSurface surface;
+
+void init_window();
+void init_egl();
+void deinit_egl();
+void deinit_window();
+void swap_window();

--- a/src/platform/kmsdrm/main.cpp
+++ b/src/platform/kmsdrm/main.cpp
@@ -1,0 +1,444 @@
+#include <string.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+#include <linux/input.h>
+#include <unistd.h>
+#include <pwd.h>
+#include <pthread.h>
+//#include <EGL/egl.h>
+#include <fcntl.h>
+#include <linux/input.h>
+#include <libudev.h>
+#include <alsa/asoundlib.h>
+
+#include "context.h"
+
+#include "game.h"
+
+#define WND_TITLE    "OpenLara"
+
+
+
+// timing
+unsigned int startTime;
+
+int osGetTime() {
+    timeval t;
+    gettimeofday(&t, NULL);
+    return int((t.tv_sec - startTime) * 1000 + t.tv_usec / 1000);
+}
+
+// sound
+snd_pcm_uframes_t   SND_FRAMES = 512;
+snd_pcm_t           *sndOut;
+Sound::Frame        *sndData;
+pthread_t           sndThread;
+
+void* sndFill(void *arg) {
+    while (sndOut) {
+        Sound::fill(sndData, SND_FRAMES);
+
+        int err = snd_pcm_writei(sndOut, sndData, SND_FRAMES);
+        if (err < 0) {
+            LOG("! sound: write %s\n", snd_strerror(err));;
+            if (err != -EPIPE)
+                break;
+
+            err = snd_pcm_recover(sndOut, err, 0);
+            if (err < 0) {
+                LOG("! sound: failed to recover\n");
+                break;
+            }
+            snd_pcm_prepare(sndOut);
+        }
+    }
+    return NULL;
+}
+
+bool sndInit() {
+    unsigned int freq = 44100;
+
+    int err;
+    if ((err = snd_pcm_open(&sndOut, "default", SND_PCM_STREAM_PLAYBACK, 0)) < 0) {
+        LOG("! sound: open %s\n", snd_strerror(err));\
+        sndOut = NULL;
+        return false;
+    }
+
+    snd_pcm_hw_params_t *params;
+
+    snd_pcm_hw_params_alloca(&params);
+    snd_pcm_hw_params_any(sndOut, params);
+    snd_pcm_hw_params_set_access(sndOut, params, SND_PCM_ACCESS_RW_INTERLEAVED);
+
+    snd_pcm_hw_params_set_channels(sndOut, params, 2);
+    snd_pcm_hw_params_set_format(sndOut, params, SND_PCM_FORMAT_S16_LE);
+    snd_pcm_hw_params_set_rate_near(sndOut, params, &freq, NULL);
+
+    snd_pcm_hw_params_set_periods(sndOut, params, 4, 0);
+    snd_pcm_hw_params_set_period_size_near(sndOut, params, &SND_FRAMES, NULL);
+    snd_pcm_hw_params_get_period_size(params, &SND_FRAMES, 0);
+
+    snd_pcm_hw_params(sndOut, params);
+    snd_pcm_prepare(sndOut);
+
+    sndData = new Sound::Frame[SND_FRAMES];
+    memset(sndData, 0, SND_FRAMES * sizeof(Sound::Frame));
+    if ((err = snd_pcm_writei(sndOut, sndData, SND_FRAMES)) < 0) {
+        LOG("! sound: write %s\n", snd_strerror(err));\
+        sndOut = NULL;
+    }
+
+    snd_pcm_start(sndOut);
+    pthread_create(&sndThread, NULL, sndFill, NULL);
+
+    return true;
+}
+
+void sndFree() {
+    pthread_cancel(sndThread);
+    snd_pcm_drop(sndOut);
+    snd_pcm_drain(sndOut);
+    snd_pcm_close(sndOut);
+    delete[] sndData;
+}
+
+// Input
+#define MAX_INPUT_DEVICES 16
+int inputDevices[MAX_INPUT_DEVICES];
+
+udev *udevObj;
+udev_monitor *udevMon;
+int udevMon_fd;
+
+vec2 joyL, joyR;
+
+bool osJoyReady(int index) {
+    return index == 0; // TODO
+}
+
+void osJoyVibrate(int index, float L, float R) {
+    // TODO
+}
+
+InputKey codeToInputKey(int code) {
+    switch (code) {
+    // keyboard
+        case KEY_LEFT       : return ikLeft;
+        case KEY_RIGHT      : return ikRight;
+        case KEY_UP         : return ikUp;
+        case KEY_DOWN       : return ikDown;
+        case KEY_SPACE      : return ikSpace;
+        case KEY_TAB        : return ikTab;
+        case KEY_ENTER      : return ikEnter;
+        case KEY_ESC        : return ikEscape;
+        case KEY_LEFTSHIFT  :
+        case KEY_RIGHTSHIFT : return ikShift;
+        case KEY_LEFTCTRL   :
+        case KEY_RIGHTCTRL  : return ikCtrl;
+        case KEY_LEFTALT    :
+        case KEY_RIGHTALT   : return ikAlt;
+        case KEY_0          : return ik0;
+        case KEY_1          : return ik1;
+        case KEY_2          : return ik2;
+        case KEY_3          : return ik3;
+        case KEY_4          : return ik4;
+        case KEY_5          : return ik5;
+        case KEY_6          : return ik6;
+        case KEY_7          : return ik7;
+        case KEY_8          : return ik8;
+        case KEY_9          : return ik9;
+        case KEY_A          : return ikA;
+        case KEY_B          : return ikB;
+        case KEY_C          : return ikC;
+        case KEY_D          : return ikD;
+        case KEY_E          : return ikE;
+        case KEY_F          : return ikF;
+        case KEY_G          : return ikG;
+        case KEY_H          : return ikH;
+        case KEY_I          : return ikI;
+        case KEY_J          : return ikJ;
+        case KEY_K          : return ikK;
+        case KEY_L          : return ikL;
+        case KEY_M          : return ikM;
+        case KEY_N          : return ikN;
+        case KEY_O          : return ikO;
+        case KEY_P          : return ikP;
+        case KEY_Q          : return ikQ;
+        case KEY_R          : return ikR;
+        case KEY_S          : return ikS;
+        case KEY_T          : return ikT;
+        case KEY_U          : return ikU;
+        case KEY_V          : return ikV;
+        case KEY_W          : return ikW;
+        case KEY_X          : return ikX;
+        case KEY_Y          : return ikY;
+        case KEY_Z          : return ikZ;
+        case KEY_HOMEPAGE   : return ikEscape;
+    // mouse
+        case BTN_LEFT       : return ikMouseL;
+        case BTN_RIGHT      : return ikMouseR;
+        case BTN_MIDDLE     : return ikMouseM;
+    }
+    return ikNone;
+}
+
+JoyKey codeToJoyKey(int code) {
+    switch (code) {
+    // gamepad
+        case BTN_A          : return jkA;
+        case BTN_B          : return jkB;
+        case BTN_X          : return jkX;
+        case BTN_Y          : return jkY;
+        case BTN_TL         : return jkLB;
+        case BTN_TR         : return jkRB;
+        case BTN_SELECT     : return jkSelect;
+        case BTN_START      : return jkStart;
+        case BTN_THUMBL     : return jkL;
+        case BTN_THUMBR     : return jkR;
+        case BTN_TL2        : return jkLT;
+        case BTN_TR2        : return jkRT;
+    }
+    return jkNone;
+}
+
+int inputDevIndex(const char *node) {
+    const char *str = strstr(node, "/event");
+    if (str)
+        return atoi(str + 6);
+    return -1;
+}
+
+void inputDevAdd(const char *node) {
+    int index = inputDevIndex(node);
+    if (index != -1) {
+        inputDevices[index] = open(node, O_RDONLY | O_NONBLOCK);
+        ioctl(inputDevices[index], EVIOCGRAB, 1);
+        //LOG("input: add %s\n", node);
+    }
+}
+
+void inputDevRemove(const char *node) {
+    int index = inputDevIndex(node);
+    if (index != -1 && inputDevices[index] != -1) {
+        close(inputDevices[index]);
+        //LOG("input: remove %s\n", node);
+    }
+}
+
+bool inputInit() {
+    joyL = joyR = vec2(0);
+
+    for (int i = 0; i < MAX_INPUT_DEVICES; i++)
+        inputDevices[i] = -1;
+
+    udevObj = udev_new();
+    if (!udevObj)
+        return false;
+
+    udevMon = udev_monitor_new_from_netlink(udevObj, "udev");
+    udev_monitor_filter_add_match_subsystem_devtype(udevMon, "input", NULL);
+    udev_monitor_enable_receiving(udevMon);
+    udevMon_fd = udev_monitor_get_fd(udevMon);
+
+    udev_enumerate *e = udev_enumerate_new(udevObj);
+    udev_enumerate_add_match_subsystem(e, "input");
+    udev_enumerate_scan_devices(e);
+    udev_list_entry *devices = udev_enumerate_get_list_entry(e);
+
+    udev_list_entry *entry;
+    udev_list_entry_foreach(entry, devices) {
+        const char *path, *node;
+        udev_device *device;
+
+        path   = udev_list_entry_get_name(entry);
+        device = udev_device_new_from_syspath(udevObj, path);
+        node   = udev_device_get_devnode(device);
+
+        if (node)
+            inputDevAdd(node);
+    }
+    udev_enumerate_unref(e);
+
+    return true;
+}
+
+void inputFree() {
+    for (int i = 0; i < MAX_INPUT_DEVICES; i++)
+        if (inputDevices[i] != -1)
+            close(inputDevices[i]);
+    udev_monitor_unref(udevMon);
+    udev_unref(udevObj);
+}
+
+#define JOY_DEAD_ZONE_STICK      8192
+
+float joyAxisValue(int value) {
+    if (value > -JOY_DEAD_ZONE_STICK && value < JOY_DEAD_ZONE_STICK)
+        return 0.0f;
+    return value / 32767.0f;
+}
+
+float joyTrigger(int value) {
+    return min(1.0f, value / 255.0f);
+}
+
+vec2 joyDir(const vec2 &value) {
+    float dist = min(1.0f, value.length());
+    return value.normal() * dist;
+}
+
+void inputUpdate() {
+// get input events
+    input_event events[16];
+
+    for (int i = 0; i < MAX_INPUT_DEVICES; i++) {
+        if (inputDevices[i] == -1) continue;
+        int rb = read(inputDevices[i], events, sizeof(events));
+
+        int joyIndex = 0; // TODO: joy index
+
+        input_event *e = events;
+        while (rb > 0) {
+            switch (e->type) {
+                case EV_KEY : {
+                    InputKey key = codeToInputKey(e->code);
+                    if (key != ikNone) {
+                        if (key == ikMouseL || key == ikMouseR || key == ikMouseM)
+                            Input::setPos(key, Input::mouse.pos);
+                        Input::setDown(key, e->value != 0);
+                    } else {
+                        JoyKey key = codeToJoyKey(e->code);
+                        Input::setJoyDown(joyIndex, key, e->value != 0);
+                    }
+                    break;
+                }
+                case EV_REL : {
+                    vec2 delta(0);
+                    delta[e->code] = float(e->value);
+                    Input::setPos(ikMouseL, Input::mouse.pos + delta);
+                    break;
+                }
+                case EV_ABS : {
+                    switch (e->code) {
+                    // Left stick
+                        case ABS_X  : joyL.x = joyAxisValue(e->value); break;
+                        case ABS_Y  : joyL.y = joyAxisValue(e->value); break;
+                    // Right stick
+                        case ABS_RX : joyR.x = joyAxisValue(e->value); break;
+                        case ABS_RY : joyR.y = joyAxisValue(e->value); break;
+                    // Left trigger
+                        case ABS_Z  : Input::setJoyPos(joyIndex, jkLT, joyTrigger(e->value)); break;
+                    // Right trigger
+                        case ABS_RZ : Input::setJoyPos(joyIndex, jkRT, joyTrigger(e->value)); break;
+                    // D-PAD
+                        case ABS_HAT0X    :
+                        case ABS_THROTTLE :
+                            Input::setJoyDown(joyIndex, jkLeft,  e->value < 0);
+                            Input::setJoyDown(joyIndex, jkRight, e->value > 0);
+                            break;
+                        case ABS_HAT0Y    :
+                        case ABS_RUDDER   :
+                            Input::setJoyDown(joyIndex, jkUp,    e->value < 0);
+                            Input::setJoyDown(joyIndex, jkDown,  e->value > 0);
+                            break;
+                    }
+
+                    Input::setJoyPos(joyIndex, jkL, joyDir(joyL));
+                    Input::setJoyPos(joyIndex, jkR, joyDir(joyR));
+                }
+            }
+            //LOG("input: type = %d, code = %d, value = %d\n", int(e->type), int(e->code), int(e->value));
+            e++;
+            rb -= sizeof(events[0]);
+        }
+    }
+
+// monitoring plug and unplug input devices
+    fd_set fds;
+    FD_ZERO(&fds);
+    FD_SET(udevMon_fd, &fds);
+
+    timeval tv;
+    tv.tv_sec  = 0;
+    tv.tv_usec = 0;
+
+    if (select(udevMon_fd + 1, &fds, NULL, NULL, &tv) > 0 && FD_ISSET(udevMon_fd, &fds)) {
+        udev_device *device = udev_monitor_receive_device(udevMon);
+        if (device) {
+            const char *node = udev_device_get_devnode(device);
+            if (node) {
+                const char *action = udev_device_get_action(device);
+                if (!strcmp(action, "add"))
+                    inputDevAdd(node);
+                if (!strcmp(action, "remove"))
+                    inputDevRemove(node);
+            }
+            udev_device_unref(device);
+        } else
+            LOG("! input: receive_device\n");
+    }
+}
+
+char Stream::cacheDir[255];
+char Stream::contentDir[255];
+
+extern int physical_width;
+extern int physical_height;
+extern EGLDisplay display;
+
+int main(int argc, char **argv) {
+  
+    init_window();
+ 
+    init_egl();
+
+    Core::width  = physical_width;
+    Core::height = physical_height;
+
+    Stream::contentDir[0] = Stream::cacheDir[0] = 0;
+
+    const char *home;
+    if (!(home = getenv("HOME")))
+        home = getpwuid(getuid())->pw_dir;
+    strcat(Stream::cacheDir, home);
+    strcat(Stream::cacheDir, "/.OpenLara/");
+
+    struct stat st = {0};
+    if (stat(Stream::cacheDir, &st) == -1 && mkdir(Stream::cacheDir, 0777) == -1)
+        Stream::cacheDir[0] = 0;
+
+    timeval t;
+    gettimeofday(&t, NULL);
+    startTime = t.tv_sec;
+
+    sndInit();
+
+    char *lvlName = argc > 1 ? argv[1] : NULL;
+
+    Game::init(lvlName);
+
+    inputInit(); // initialize and grab input devices
+
+    while (!Core::isQuit) {
+        inputUpdate();
+
+        if (Game::update()) {
+            Game::render();
+            Core::waitVBlank();
+
+            // Calls the eglSwap and the drm flip functions one after another, as it's meant to be.
+            swap_window();
+        }
+    };
+
+    inputFree();
+
+    sndFree();
+    Game::deinit();
+
+    deinit_egl();
+    deinit_window();
+
+    return 0;
+}


### PR DESCRIPTION
Hi there, XProger

I have "plumbered" a kms/drm rendering context, intended for modern X-less GNU/Linux systems. It's a bit redundant because there's a RetroArch port, but it may be useful to have an standalone version of OpenLara working on the modern Linux framebuffer infraestructure.

At the moment, only FMV videos are displayed: it segfaults before it can render the menu, but I have been looking at all EGL functions and it seems fine to me. I *believe* I am using the right EGL context parameters. Could you please try to help me finding what's wrong? I am not an OpenGL expert, and I don't know the engine innards either, so maybe you can lend a hand.