### PR TITLE
Snap Rotation

### DIFF
--- a/bin/TombRaidervr_actions.json
+++ b/bin/TombRaidervr_actions.json
@@ -43,6 +43,10 @@
       {
          "name" : "/actions/demo/in/Start",
          "type" : "boolean"
+      },
+	  {
+         "name" : "/actions/demo/in/Toggle",
+         "type" : "boolean"
       }
    ],
    "default_bindings" : [

--- a/bin/system_generated_openlara_exe_binding_holographic_controller.json
+++ b/bin/system_generated_openlara_exe_binding_holographic_controller.json
@@ -85,11 +85,11 @@
             {
                "inputs" : {
                   "click" : {
-                     "output" : "/actions/demo/in/start"
+                     "output" : "/actions/demo/in/roll"
                   }
                },
                "mode" : "button",
-               "path" : "/user/hand/right/input/application_menu"
+               "path" : "/user/hand/right/input/grip"
             },
             {
                "inputs" : {
@@ -103,18 +103,18 @@
             {
                "inputs" : {
                   "click" : {
-                     "output" : "/actions/demo/in/roll"
+                     "output" : "/actions/demo/in/toggle"
                   }
                },
                "mode" : "button",
-               "path" : "/user/hand/right/input/grip"
+               "path" : "/user/hand/right/input/application_menu"
             }
          ]
       }
    },
    "controller_type" : "holographic_controller",
    "description" : "",
-   "name" : "OpenLaraTestWMRBinding",
+   "name" : "OpenLaraTestWMRBindingWithToggle",
    "options" : {},
    "simulated_actions" : []
 }

--- a/src/camera.h
+++ b/src/camera.h
@@ -153,8 +153,8 @@ struct Camera : ICamera {
     bool updateFirstPerson() {
         Basis &joint = owner->getJoint(owner->jointHead);
 
-        if (mode != MODE_CUTSCENE && !owner->useHeadAnimation()) { //enters here
-            targetAngle.x += PI; // don't change this
+        if (mode != MODE_CUTSCENE && !owner->useHeadAnimation()) { 
+            targetAngle.x += PI; 
             targetAngle.z = -targetAngle.z;
 
             vec3 pos = joint.pos - joint.rot * vec3(0, 48, -24);
@@ -169,43 +169,14 @@ struct Camera : ICamera {
         }
 
         if (Core::settings.detail.stereo == Core::Settings::STEREO_VR) {
-           //fpHead.rot = quat(vec3(1, 0, 0), PI);  // whats here
             hmdRotation = fpHead.rot;
             if (Input::hmd.resetAngle) {
-               //fpHead.rot = fpHead.rot * quat(vec3(1, 0, 0),PI);
-                //fpHead.rot = fpHead.rot * rotYXZ(owner->angle);
-                //vec3 var = owner->angle - targetAngle; // they're the same idiot
-                vec3 var;
-                //if (Input::hmd.centerAngle) {
-                //    //var = vec3(PI, owner->angle.y, 0) /** DEG2RAD*/;
-                //    var = targetAngle;
-                //}
-                //else {
-                //    var = vec3(PI, 0, 0);
-                //}
-                //var = targetAngle;
-                //if (owner->angle.y != targetAngle.y) {
-                //    var = owner->angle - targetAngle;
-                //}
-                //else {
-                //    var = targetAngle + vec3(0,1,0);
-                //}
-                //auto rotate = rotYXZ(hmdAngle);
-                //auto var = rotate * 0.5;
-                //fpHead.rot = rotate /** quat(vec3(1, 0, 0), PI)*/; // pI / // this sucks
                 fpHead.rot = lastRotation;
-                //fpHead.rot = quat(vec3(1, 0, 0), PI) * rotYXZ(owner->angle /** vec3(1,0,0)*/) ; // pI / // this sucks
-                //fpHead.rot = rotYXZ(targetAngle * vec3(1,0,0)); // the problem
-                //fpHead.rot = quat(vec3(1, 0, 0), PI);
-                //fpHead.rot = fpHead.rot * quat(vec3(1, 0, 0), PI);
-                //fpHead.rot = rotYXZ(lara.getAngleAbs(Input::hmd.head.dir().xyz())) * quat(vec3(1, 0, 0), PI);
-                //fpHead.rot = quat(vec3(1,0,0),PI) * rotYXZ(owner->angle);
             }
             else {
                 fpHead.rot = hmdRotation;
             }
         }
-        // its got to be here
         mViewInv.identity();
         mViewInv.setRot(fpHead.rot);
         mViewInv.setPos(fpHead.pos);
@@ -415,8 +386,6 @@ struct Camera : ICamera {
         } else {
            if (Core::settings.detail.stereo == Core::Settings::STEREO_VR) {
                lookAngle = vec3(0.0f); 
-               //lookAngle = Input::hmd.head.dir().xyz(); // doesn't work
-               //copied
            } else {
                 if (mode == MODE_LOOK) {
                     float d = 3.0f * Core::deltaTime;
@@ -580,9 +549,9 @@ struct Camera : ICamera {
         this->firstPerson = firstPerson;
 
         if (firstPerson)
-            smooth = false; // was false
+            smooth = false;
 
-        fov   = firstPerson ? 90.0f : 65.0f; // was 90
+        fov   = firstPerson ? 90.0f : 65.0f;
         znear = firstPerson ? 16.0f : 32.0f;
         zfar  = 45.0f * 1024.0f;
 

--- a/src/camera.h
+++ b/src/camera.h
@@ -167,7 +167,7 @@ struct Camera : ICamera {
         }
 
         if (Core::settings.detail.stereo == Core::Settings::STEREO_VR) {
-            fpHead.rot = quat(vec3(1, 0, 0), PI);
+           //fpHead.rot = quat(vec3(1, 0, 0), PI);  // whats here
         }
 
         mViewInv.identity();
@@ -377,9 +377,10 @@ struct Camera : ICamera {
             } else
                 updateFirstPerson();
         } else {
-            if (Core::settings.detail.stereo == Core::Settings::STEREO_VR) {
-                lookAngle = vec3(0.0f);
-            } else {
+           if (Core::settings.detail.stereo == Core::Settings::STEREO_VR) {
+               lookAngle = vec3(0.0f); // what's going on here // was 0
+               //lookAngle = Input::hmd.head.dir().xyz();
+           } else {
                 if (mode == MODE_LOOK) {
                     float d = 3.0f * Core::deltaTime;
 

--- a/src/camera.h
+++ b/src/camera.h
@@ -25,7 +25,9 @@ struct Camera : ICamera {
     Frustum    *frustum;
 
     float       fov, aspect, znear, zfar;
-    vec3        lookAngle, targetAngle;
+    vec3        lookAngle, targetAngle, hmdAngle; // hmdAngle used to correct during vr
+    quat        lastRotation = quat(vec3(1,0,0),PI) ;
+    quat        hmdRotation;
     mat4        mViewInv;
 
     float       timer;
@@ -152,7 +154,7 @@ struct Camera : ICamera {
         Basis &joint = owner->getJoint(owner->jointHead);
 
         if (mode != MODE_CUTSCENE && !owner->useHeadAnimation()) { //enters here
-            targetAngle.x += PI;
+            targetAngle.x += PI; // don't change this
             targetAngle.z = -targetAngle.z;
 
             vec3 pos = joint.pos - joint.rot * vec3(0, 48, -24);
@@ -168,13 +170,39 @@ struct Camera : ICamera {
 
         if (Core::settings.detail.stereo == Core::Settings::STEREO_VR) {
            //fpHead.rot = quat(vec3(1, 0, 0), PI);  // whats here
-            auto temp = fpHead.rot;
+            hmdRotation = fpHead.rot;
             if (Input::hmd.resetAngle) {
-                fpHead.rot = quat(vec3(1, 0, 0), PI);
-                //fpHead.rot = rotYXZ(owner->angle);
+               //fpHead.rot = fpHead.rot * quat(vec3(1, 0, 0),PI);
+                //fpHead.rot = fpHead.rot * rotYXZ(owner->angle);
+                //vec3 var = owner->angle - targetAngle; // they're the same idiot
+                vec3 var;
+                //if (Input::hmd.centerAngle) {
+                //    //var = vec3(PI, owner->angle.y, 0) /** DEG2RAD*/;
+                //    var = targetAngle;
+                //}
+                //else {
+                //    var = vec3(PI, 0, 0);
+                //}
+                //var = targetAngle;
+                //if (owner->angle.y != targetAngle.y) {
+                //    var = owner->angle - targetAngle;
+                //}
+                //else {
+                //    var = targetAngle + vec3(0,1,0);
+                //}
+                //auto rotate = rotYXZ(hmdAngle);
+                //auto var = rotate * 0.5;
+                //fpHead.rot = rotate /** quat(vec3(1, 0, 0), PI)*/; // pI / // this sucks
+                fpHead.rot = lastRotation;
+                //fpHead.rot = quat(vec3(1, 0, 0), PI) * rotYXZ(owner->angle /** vec3(1,0,0)*/) ; // pI / // this sucks
+                //fpHead.rot = rotYXZ(targetAngle * vec3(1,0,0)); // the problem
+                //fpHead.rot = quat(vec3(1, 0, 0), PI);
+                //fpHead.rot = fpHead.rot * quat(vec3(1, 0, 0), PI);
+                //fpHead.rot = rotYXZ(lara.getAngleAbs(Input::hmd.head.dir().xyz())) * quat(vec3(1, 0, 0), PI);
+                //fpHead.rot = quat(vec3(1,0,0),PI) * rotYXZ(owner->angle);
             }
             else {
-                fpHead.rot = temp;
+                fpHead.rot = hmdRotation;
             }
         }
         // its got to be here
@@ -552,9 +580,9 @@ struct Camera : ICamera {
         this->firstPerson = firstPerson;
 
         if (firstPerson)
-            smooth = false;
+            smooth = false; // was false
 
-        fov   = firstPerson ? 90.0f : 65.0f;
+        fov   = firstPerson ? 90.0f : 65.0f; // was 90
         znear = firstPerson ? 16.0f : 32.0f;
         zfar  = 45.0f * 1024.0f;
 

--- a/src/camera.h
+++ b/src/camera.h
@@ -176,31 +176,6 @@ struct Camera : ICamera {
             else {
                 fpHead.rot = temp;
             }
-           //if (Input::down[ikLeft] || Input::down[ikRight]) {
-           //    //fpHead.rot = temp;
-           //    //quat rot = rotYXZ(owner->angle);
-           //    ////fpHead.pos = pos;
-           //    //fpHead.rot = fpHead.rot.lerp(rot, smooth ? Core::deltaTime * 10.0f : 1.0f);
-           //    //fpHead.rot = quat(vec3(1, 0, 0), PI);
-           //}
-           //else {
-           //    fpHead.rot = quat(vec3(1, 0, 0), PI);
-           //}
-           ////copied
-           //if (mode != MODE_CUTSCENE && !owner->useHeadAnimation()) {
-           //    targetAngle.x += PI;
-           //    targetAngle.z = -targetAngle.z;
-
-           //    vec3 pos = joint.pos - joint.rot * vec3(0, 48, -24);
-           //    quat rot = rotYXZ(targetAngle);
-           //    fpHead.pos = pos;
-           //    fpHead.rot = fpHead.rot.lerp(rot, smooth ? Core::deltaTime * 10.0f : 1.0f);
-           //}
-           //else {
-           //    fpHead = joint;
-           //    fpHead.rot = fpHead.rot * quat(vec3(1, 0, 0), PI);
-           //    fpHead.pos -= joint.rot * vec3(0, 48, -24);
-           //}
         }
         // its got to be here
         mViewInv.identity();

--- a/src/camera.h
+++ b/src/camera.h
@@ -151,7 +151,7 @@ struct Camera : ICamera {
     bool updateFirstPerson() {
         Basis &joint = owner->getJoint(owner->jointHead);
 
-        if (mode != MODE_CUTSCENE && !owner->useHeadAnimation()) {
+        if (mode != MODE_CUTSCENE && !owner->useHeadAnimation()) { //enters here
             targetAngle.x += PI;
             targetAngle.z = -targetAngle.z;
 
@@ -168,8 +168,41 @@ struct Camera : ICamera {
 
         if (Core::settings.detail.stereo == Core::Settings::STEREO_VR) {
            //fpHead.rot = quat(vec3(1, 0, 0), PI);  // whats here
-        }
+            auto temp = fpHead.rot;
+            if (Input::hmd.resetAngle) {
+                fpHead.rot = quat(vec3(1, 0, 0), PI);
+                //fpHead.rot = rotYXZ(owner->angle);
+            }
+            else {
+                fpHead.rot = temp;
+            }
+           //if (Input::down[ikLeft] || Input::down[ikRight]) {
+           //    //fpHead.rot = temp;
+           //    //quat rot = rotYXZ(owner->angle);
+           //    ////fpHead.pos = pos;
+           //    //fpHead.rot = fpHead.rot.lerp(rot, smooth ? Core::deltaTime * 10.0f : 1.0f);
+           //    //fpHead.rot = quat(vec3(1, 0, 0), PI);
+           //}
+           //else {
+           //    fpHead.rot = quat(vec3(1, 0, 0), PI);
+           //}
+           ////copied
+           //if (mode != MODE_CUTSCENE && !owner->useHeadAnimation()) {
+           //    targetAngle.x += PI;
+           //    targetAngle.z = -targetAngle.z;
 
+           //    vec3 pos = joint.pos - joint.rot * vec3(0, 48, -24);
+           //    quat rot = rotYXZ(targetAngle);
+           //    fpHead.pos = pos;
+           //    fpHead.rot = fpHead.rot.lerp(rot, smooth ? Core::deltaTime * 10.0f : 1.0f);
+           //}
+           //else {
+           //    fpHead = joint;
+           //    fpHead.rot = fpHead.rot * quat(vec3(1, 0, 0), PI);
+           //    fpHead.pos -= joint.rot * vec3(0, 48, -24);
+           //}
+        }
+        // its got to be here
         mViewInv.identity();
         mViewInv.setRot(fpHead.rot);
         mViewInv.setPos(fpHead.pos);
@@ -378,8 +411,9 @@ struct Camera : ICamera {
                 updateFirstPerson();
         } else {
            if (Core::settings.detail.stereo == Core::Settings::STEREO_VR) {
-               lookAngle = vec3(0.0f); // what's going on here // was 0
-               //lookAngle = Input::hmd.head.dir().xyz();
+               lookAngle = vec3(0.0f); 
+               //lookAngle = Input::hmd.head.dir().xyz(); // doesn't work
+               //copied
            } else {
                 if (mode == MODE_LOOK) {
                     float d = 3.0f * Core::deltaTime;

--- a/src/input.h
+++ b/src/input.h
@@ -35,10 +35,12 @@ namespace Input {
 
     struct HMD {
         mat4 head;
+        mat4 lastHead; // last head position
         mat4 eye[2];
         mat4 proj[2];
         mat4 controllers[2];
         vec3 zero;
+        bool resetAngle = true; // whether or not the angle of lara should be rest to hmd angle
         bool ready;
         bool state[cMAX];
 

--- a/src/input.h
+++ b/src/input.h
@@ -41,6 +41,7 @@ namespace Input {
         mat4 controllers[2];
         vec3 zero;
         bool resetAngle = true; // whether or not the angle of lara should be rest to hmd angle
+        bool centerAngle = true; // find reference for head position 
         bool ready;
         bool state[cMAX];
 

--- a/src/input.h
+++ b/src/input.h
@@ -44,6 +44,9 @@ namespace Input {
         bool centerAngle = true; // find reference for head position 
         bool ready;
         bool state[cMAX];
+        bool rotationState = true; // mioght do an int here
+        //enum rotationModeValues{STANDARD,IMMERSIVE};
+        int rotationMode = 1;
 
         void setView(const mat4 &pL, const mat4 &pR, const mat4 &vL, const mat4 &vR) {
             proj[0] = pL;

--- a/src/input.h
+++ b/src/input.h
@@ -44,9 +44,8 @@ namespace Input {
         bool centerAngle = true; // find reference for head position 
         bool ready;
         bool state[cMAX];
-        bool rotationState = true; // mioght do an int here
-        //enum rotationModeValues{STANDARD,IMMERSIVE};
-        int rotationMode = 1;
+        bool rotationState = true; // state of rotation toggle
+        int rotationMode = 1; // acts like a tristate switch
 
         void setView(const mat4 &pL, const mat4 &pR, const mat4 &vL, const mat4 &vR) {
             proj[0] = pL;

--- a/src/lara.h
+++ b/src/lara.h
@@ -3051,10 +3051,8 @@ struct Lara : Character {
            vec3 diff;
            if (first) {
                ang = getAngleAbs(Input::hmd.head.dir().xyz());
-               //ang = getAngle(Input::hmd.head.dir().xyz());
                angle.y = ang.y;
                first = false;
-               //camera->hmdAngle = vec3(PI, 0, 0);
                return input;
            }
 
@@ -3065,83 +3063,25 @@ struct Lara : Character {
                 Input::hmd.resetAngle = true;
                 Input::hmd.centerAngle = true;
                 camera->lastRotation = camera->hmdRotation;
-                //might break
-                return input;
-               // first = true;
 
             }
             if (Input::hmd.centerAngle) {
                 Input::hmd.lastHead = Input::hmd.head;
                 lastAngle = angle;
-                //lastAngle = getAngleAbs(Input::hmd.head.dir().xyz()); // last angle from the head
                 Input::hmd.centerAngle = false;
-                camera->hmdAngle = camera->targetAngle;
-                return input;
             }
            
-          if (Input::hmd.resetAngle) {
-               //ang = getAngleAbs(Input::hmd.head.dir().xyz());
-              //ang = getAngleAbs(Input::hmd.head.dir().xyz()) - getAngleAbs(Input::hmd.lastHead.dir().xyz());
-              //ang = camera->angle;
-              //ang += getAngle(Input::hmd.lastHead.dir().xyz()) - getAngle(Input::hmd.head.dir().xyz());
-              //ang = getAngle(Input::hmd.lastHead.dir().xyz()) - getAngle(Input::hmd.head.dir().xyz()); // difference
-              //ang = getAngleAbs(Input::hmd.lastHead.dir().xyz() - (Input::hmd.head.dir().xyz()));
-              ang = getAngleAbs(Input::hmd.lastHead.dir().xyz()) - getAngleAbs(Input::hmd.head.dir().xyz()); // difference
-              //apply difference to 
-              diff = lastAngle - ang; // was lastAngle
-                //camera->angle = getAngleAbs(Input::hmd.head.dir().xyz());
-                //ang = camera->angle;
-              angle.y = diff.y;
-              //camera->hmdAngle = vec3(PI, 0, 0);
-              //camera->hmdAngle = camera->targetAngle;
-              //angle.y = ang.y;
-              //angle.y += diff.y - angle.y;
+            if (Input::hmd.resetAngle) {
+                ang = getAngleAbs(Input::hmd.lastHead.dir().xyz()) - getAngleAbs(Input::hmd.head.dir().xyz()); 
+                diff = lastAngle - ang; 
+                angle.y = diff.y;
 
-
-              //angle.y = diff.y;
-             //rotateY((diff.y - angle.y)); // diff.y - ang.y // close
-              //rot
-              //angle.y = clampAngle(diff.y);
-                //Input::hmd.resetAngle = false;
-           }
-
-
-
-
-
-
-
-
-           // else {
-                //ang = getAngleAbs(Input::hmd.head.dir().xyz());
-                //angle.y = ang.y;
-                //ang = getAngleAbs(Input::hmd.lastHead.dir().xyz()) - getAngleAbs(Input::hmd.head.dir().xyz());
-                //ang = getAngle(Input::hmd.lastHead.dir().xyz()) - getAngle(Input::hmd.head.dir().xyz());
-                //ang = getAngleAbs(Input::hmd.lastHead.dir().xyz() - (Input::hmd.head.dir().xyz()));
-                //angle.y -= ang.y; // adding difference between hmd frames // 360 = 360 ,but lara doesn't rotate enough(0.25) // method is not working
-                //rotateY(ang.y);
-                //angle.y = clampAngle(angle.y + (ang.y) );
-                //Input::hmd.head.dir().xyz() += ang.y;
-            //}
-
-            
-            //else {
-               //ang = getAngleAbs(Input::hmd.head.dir().xyz());
-               //camera->targetAngle = ang;
-               //camera->lookAngle = ang;
-               //angle.y = ang.y; // add incrementer based on button press, doesn't work with rotFactor.y
-               //rotateY(ang.y);
-               //angle.y = clampAngle(angle.y + (-ang.y) );
-            //}
-            if (!(input & (FORTH | BACK))) {
-                //rotateY();
-            
+                if (stand == STAND_UNDERWATER) {
+                    //input &= ~(FORTH | BACK);
+                    angle.x = diff.x;
+                }
             }
 
-            if (stand == STAND_UNDERWATER) {
-                input &= ~(FORTH | BACK);
-                angle.x = ang.x;
-            }
         }
         return input;
     }

--- a/src/lara.h
+++ b/src/lara.h
@@ -3042,14 +3042,39 @@ struct Lara : Character {
         if (Core::settings.detail.stereo == Core::Settings::STEREO_VR && camera->firstPerson && canFreeRotate()) {
 
             if (!(input & WALK)) {
-                input &= ~(LEFT | RIGHT);
+            //    input &= ~(LEFT | RIGHT); // commented out to allow side jumping in VR
             }
 
-            vec3 ang = getAngleAbs(Input::hmd.head.dir().xyz());
-            angle.y = ang.y;
+
+            
+            vec3 ang;
+            if (Input::hmd.resetAngle) {
+                ang = getAngleAbs(Input::hmd.head.dir().xyz()); 
+                angle.y = ang.y;
+                Input::hmd.resetAngle = false;
+            }
+            else {
+                //ang = getAngleAbs(Input::hmd.head.dir().xyz());
+                //angle.y = ang.y;
+                ang = getAngleAbs(Input::hmd.lastHead.dir().xyz()) - getAngleAbs(Input::hmd.head.dir().xyz());
+                angle.y -= ang.y * 1.5 ; // adding difference between hmd frames // 360 = 360 ,but lara doesn't rotate enough(0.25) // method is not working
+            }
+
+            //if (Input::down[ikLeft]) {
+            //    rotateY(1);
+            //}
+            //else {
+            //    vec3 ang = getAngleAbs(Input::hmd.head.dir().xyz());
+            //    angle.y = ang.y; // add incrementer based on button press, doesn't work with rotFactor.y
+            //}
+            if (!(input & (FORTH | BACK))) {
+                //rotateY();
+            
+            }
+
             if (stand == STAND_UNDERWATER) {
                 input &= ~(FORTH | BACK);
-                angle.x = ang.x;
+              //  angle.x = ang.x;
             }
         }
         return input;
@@ -3282,7 +3307,7 @@ struct Lara : Character {
             w *= TURN_WATER_FAST;
         else if (state == STATE_RUN) {
             if (Core::settings.detail.stereo == Core::Settings::STEREO_VR)
-                w *= TURN_FAST;
+                w *= TURN_FAST; // added *2
             else
                 w *= sign(w) != sign(tilt) ? 0.0f : w * TURN_FAST * tilt / LARA_TILT_MAX;
         } else if (state == STATE_FAST_TURN)

--- a/src/lara.h
+++ b/src/lara.h
@@ -3046,26 +3046,58 @@ struct Lara : Character {
             }
 
 
-            
-            vec3 ang;
-            if (Input::hmd.resetAngle) {
-                ang = getAngleAbs(Input::hmd.head.dir().xyz()); 
-                angle.y = ang.y;
+            //if (Input::down[ikLeft] || Input::down[ikRight]) {
+            //    Input::hmd.resetAngle = false;
+            //}
+            if (Input::down[ik1]) {
                 Input::hmd.resetAngle = false;
             }
-            else {
+            if (Input::down[ik2]) {
+                Input::hmd.resetAngle = true;
+            }
+           vec3 ang;
+          if (Input::hmd.resetAngle) {
+               ang = getAngleAbs(Input::hmd.head.dir().xyz());
+              //ang = camera->angle;
+              //ang += getAngle(Input::hmd.lastHead.dir().xyz()) - getAngle(Input::hmd.head.dir().xyz());
+              //ang = getAngle(Input::hmd.lastHead.dir().xyz()) - getAngle(Input::hmd.head.dir().xyz());
+
+                //camera->angle = getAngleAbs(Input::hmd.head.dir().xyz());
+                //ang = camera->angle;
+                angle.y = ang.y;
+                //Input::hmd.resetAngle = false;
+           }
+
+
+
+
+
+
+
+
+           // else {
                 //ang = getAngleAbs(Input::hmd.head.dir().xyz());
                 //angle.y = ang.y;
-                ang = getAngleAbs(Input::hmd.lastHead.dir().xyz()) - getAngleAbs(Input::hmd.head.dir().xyz());
-                angle.y -= ang.y * 1.5 ; // adding difference between hmd frames // 360 = 360 ,but lara doesn't rotate enough(0.25) // method is not working
-            }
-
-            //if (Input::down[ikLeft]) {
-            //    rotateY(1);
+                //ang = getAngleAbs(Input::hmd.lastHead.dir().xyz()) - getAngleAbs(Input::hmd.head.dir().xyz());
+                //ang = getAngle(Input::hmd.lastHead.dir().xyz()) - getAngle(Input::hmd.head.dir().xyz());
+                //ang = getAngleAbs(Input::hmd.lastHead.dir().xyz() - (Input::hmd.head.dir().xyz()));
+                //angle.y -= ang.y; // adding difference between hmd frames // 360 = 360 ,but lara doesn't rotate enough(0.25) // method is not working
+                //rotateY(ang.y);
+                //angle.y = clampAngle(angle.y + (ang.y) );
+                //Input::hmd.head.dir().xyz() += ang.y;
             //}
+
+            
             //else {
-            //    vec3 ang = getAngleAbs(Input::hmd.head.dir().xyz());
-            //    angle.y = ang.y; // add incrementer based on button press, doesn't work with rotFactor.y
+               //ang = getAngleAbs(Input::hmd.head.dir().xyz());
+               //camera->targetAngle = ang;
+               //camera->lookAngle = ang;
+               //angle.y = ang.y; // add incrementer based on button press, doesn't work with rotFactor.y
+               //rotateY(ang.y);
+               //angle.y = clampAngle(angle.y + (-ang.y) );
+               if (Input::down[ikLeft]) {
+               camera->targetAngle = ang + vec3(0,1,0);
+            }
             //}
             if (!(input & (FORTH | BACK))) {
                 //rotateY();
@@ -3074,7 +3106,7 @@ struct Lara : Character {
 
             if (stand == STAND_UNDERWATER) {
                 input &= ~(FORTH | BACK);
-              //  angle.x = ang.x;
+                angle.x = ang.x;
             }
         }
         return input;

--- a/src/lara.h
+++ b/src/lara.h
@@ -65,7 +65,9 @@
 #define LARA_VIBRATE_HIT_TIME   0.2f
 
 struct Lara : Character {
-
+    // new 
+    vec3 lastAngle;
+    bool first = true;
     // http://www.tombraiderforums.com/showthread.php?t=148859
     enum {
         ANIM_RUN                = 0,
@@ -3049,22 +3051,42 @@ struct Lara : Character {
             //if (Input::down[ikLeft] || Input::down[ikRight]) {
             //    Input::hmd.resetAngle = false;
             //}
+
+           vec3 ang;
+           vec3 diff;
+
+           if (first) {
+               ang = getAngleAbs(Input::hmd.head.dir().xyz());
+               angle.y = ang.y;
+               first = false;
+           }
+
             if (Input::down[ik1]) {
                 Input::hmd.resetAngle = false;
             }
             if (Input::down[ik2]) {
                 Input::hmd.resetAngle = true;
+                Input::hmd.centerAngle = true;
+
             }
-           vec3 ang;
+            if (Input::hmd.centerAngle) {
+                Input::hmd.lastHead = Input::hmd.head;
+                lastAngle = angle;
+                Input::hmd.centerAngle = false;
+            }
+           
           if (Input::hmd.resetAngle) {
-               ang = getAngleAbs(Input::hmd.head.dir().xyz());
+               //ang = getAngleAbs(Input::hmd.head.dir().xyz());
+
               //ang = camera->angle;
               //ang += getAngle(Input::hmd.lastHead.dir().xyz()) - getAngle(Input::hmd.head.dir().xyz());
-              //ang = getAngle(Input::hmd.lastHead.dir().xyz()) - getAngle(Input::hmd.head.dir().xyz());
-
+              ang = getAngle(Input::hmd.lastHead.dir().xyz()) - getAngle(Input::hmd.head.dir().xyz()); // difference
+              //apply difference to 
+              diff = lastAngle + ang;
                 //camera->angle = getAngleAbs(Input::hmd.head.dir().xyz());
                 //ang = camera->angle;
-                angle.y = ang.y;
+                //angle.y = ang.y;
+              angle.y = diff.y;
                 //Input::hmd.resetAngle = false;
            }
 
@@ -3095,9 +3117,6 @@ struct Lara : Character {
                //angle.y = ang.y; // add incrementer based on button press, doesn't work with rotFactor.y
                //rotateY(ang.y);
                //angle.y = clampAngle(angle.y + (-ang.y) );
-               if (Input::down[ikLeft]) {
-               camera->targetAngle = ang + vec3(0,1,0);
-            }
             //}
             if (!(input & (FORTH | BACK))) {
                 //rotateY();

--- a/src/lara.h
+++ b/src/lara.h
@@ -3056,10 +3056,12 @@ struct Lara : Character {
                return input;
            }
 
-            if (Input::down[ik1]) {
+            //if(Input::hmd.immersiveRotation)
+
+            if (Input::down[ik1] || Input::hmd.rotationMode == 0) {
                 Input::hmd.resetAngle = false;
             }
-            if (Input::down[ik2]) {
+            if (Input::down[ik2] || Input::hmd.rotationMode == 1) {
                 Input::hmd.resetAngle = true;
                 Input::hmd.centerAngle = true;
                 camera->lastRotation = camera->hmdRotation;

--- a/src/lara.h
+++ b/src/lara.h
@@ -3047,18 +3047,15 @@ struct Lara : Character {
             //    input &= ~(LEFT | RIGHT); // commented out to allow side jumping in VR
             }
 
-
-            //if (Input::down[ikLeft] || Input::down[ikRight]) {
-            //    Input::hmd.resetAngle = false;
-            //}
-
            vec3 ang;
            vec3 diff;
-
            if (first) {
                ang = getAngleAbs(Input::hmd.head.dir().xyz());
+               //ang = getAngle(Input::hmd.head.dir().xyz());
                angle.y = ang.y;
                first = false;
+               //camera->hmdAngle = vec3(PI, 0, 0);
+               return input;
            }
 
             if (Input::down[ik1]) {
@@ -3067,26 +3064,44 @@ struct Lara : Character {
             if (Input::down[ik2]) {
                 Input::hmd.resetAngle = true;
                 Input::hmd.centerAngle = true;
+                camera->lastRotation = camera->hmdRotation;
+                //might break
+                return input;
+               // first = true;
 
             }
             if (Input::hmd.centerAngle) {
                 Input::hmd.lastHead = Input::hmd.head;
                 lastAngle = angle;
+                //lastAngle = getAngleAbs(Input::hmd.head.dir().xyz()); // last angle from the head
                 Input::hmd.centerAngle = false;
+                camera->hmdAngle = camera->targetAngle;
+                return input;
             }
            
           if (Input::hmd.resetAngle) {
                //ang = getAngleAbs(Input::hmd.head.dir().xyz());
-
+              //ang = getAngleAbs(Input::hmd.head.dir().xyz()) - getAngleAbs(Input::hmd.lastHead.dir().xyz());
               //ang = camera->angle;
               //ang += getAngle(Input::hmd.lastHead.dir().xyz()) - getAngle(Input::hmd.head.dir().xyz());
-              ang = getAngle(Input::hmd.lastHead.dir().xyz()) - getAngle(Input::hmd.head.dir().xyz()); // difference
+              //ang = getAngle(Input::hmd.lastHead.dir().xyz()) - getAngle(Input::hmd.head.dir().xyz()); // difference
+              //ang = getAngleAbs(Input::hmd.lastHead.dir().xyz() - (Input::hmd.head.dir().xyz()));
+              ang = getAngleAbs(Input::hmd.lastHead.dir().xyz()) - getAngleAbs(Input::hmd.head.dir().xyz()); // difference
               //apply difference to 
-              diff = lastAngle + ang;
+              diff = lastAngle - ang; // was lastAngle
                 //camera->angle = getAngleAbs(Input::hmd.head.dir().xyz());
                 //ang = camera->angle;
-                //angle.y = ang.y;
               angle.y = diff.y;
+              //camera->hmdAngle = vec3(PI, 0, 0);
+              //camera->hmdAngle = camera->targetAngle;
+              //angle.y = ang.y;
+              //angle.y += diff.y - angle.y;
+
+
+              //angle.y = diff.y;
+             //rotateY((diff.y - angle.y)); // diff.y - ang.y // close
+              //rot
+              //angle.y = clampAngle(diff.y);
                 //Input::hmd.resetAngle = false;
            }
 

--- a/src/platform/win/main.cpp
+++ b/src/platform/win/main.cpp
@@ -780,7 +780,7 @@ void vrUpdateView() {
     vR.setPos(vR.getPos() * ONE_METER);
     Input::hmd.setView(pL, pR, vL, vR);
     // set last head and current head
-    Input::hmd.lastHead = Input::hmd.head;
+    //Input::hmd.lastHead = Input::hmd.head;
     Input::hmd.head = head;
 }
 

--- a/src/platform/win/main.cpp
+++ b/src/platform/win/main.cpp
@@ -765,8 +765,8 @@ void vrUpdateView() {
     if (!tPose[vr::k_unTrackedDeviceIndex_Hmd].bPoseIsValid)
         return;
 
-    mat4 pL = convToMat4(hmd->GetProjectionMatrix(vr::Eye_Left,  8.0f, 45.0f * 1024.0f));
-    mat4 pR = convToMat4(hmd->GetProjectionMatrix(vr::Eye_Right, 8.0f, 45.0f * 1024.0f));
+    mat4 pL = convToMat4(hmd->GetProjectionMatrix(vr::Eye_Left,  8.0f, 45.0f * 1024.0f)); // was 45 *
+    mat4 pR = convToMat4(hmd->GetProjectionMatrix(vr::Eye_Right, 8.0f, 45.0f * 1024.0f)); // was 45 *
 
     mat4 head = convToMat4(tPose[vr::k_unTrackedDeviceIndex_Hmd].mDeviceToAbsoluteTracking);
     if (Input::hmd.zero.x == INF)

--- a/src/platform/win/main.cpp
+++ b/src/platform/win/main.cpp
@@ -765,8 +765,8 @@ void vrUpdateView() {
     if (!tPose[vr::k_unTrackedDeviceIndex_Hmd].bPoseIsValid)
         return;
 
-    mat4 pL = convToMat4(hmd->GetProjectionMatrix(vr::Eye_Left,  8.0f, 45.0f * 1024.0f)); // was 45 *
-    mat4 pR = convToMat4(hmd->GetProjectionMatrix(vr::Eye_Right, 8.0f, 45.0f * 1024.0f)); // was 45 *
+    mat4 pL = convToMat4(hmd->GetProjectionMatrix(vr::Eye_Left,  8.0f, 45.0f * 1024.0f)); 
+    mat4 pR = convToMat4(hmd->GetProjectionMatrix(vr::Eye_Right, 8.0f, 45.0f * 1024.0f)); 
 
     mat4 head = convToMat4(tPose[vr::k_unTrackedDeviceIndex_Hmd].mDeviceToAbsoluteTracking);
     if (Input::hmd.zero.x == INF)
@@ -779,8 +779,6 @@ void vrUpdateView() {
     vL.setPos(vL.getPos() * ONE_METER);
     vR.setPos(vR.getPos() * ONE_METER);
     Input::hmd.setView(pL, pR, vL, vR);
-    // set last head and current head
-    //Input::hmd.lastHead = Input::hmd.head;
     Input::hmd.head = head;
 }
 

--- a/src/platform/win/main.cpp
+++ b/src/platform/win/main.cpp
@@ -14,7 +14,7 @@
     #endif
 #endif
 
-//#define VR_SUPPORT
+#define VR_SUPPORT
 // TODO: fix depth precision
 // TODO: fix water surface rendering
 // TODO: fix clipping
@@ -779,7 +779,8 @@ void vrUpdateView() {
     vL.setPos(vL.getPos() * ONE_METER);
     vR.setPos(vR.getPos() * ONE_METER);
     Input::hmd.setView(pL, pR, vL, vR);
-
+    // set last head and current head
+    Input::hmd.lastHead = Input::hmd.head;
     Input::hmd.head = head;
 }
 

--- a/src/platform/win/main.cpp
+++ b/src/platform/win/main.cpp
@@ -14,7 +14,7 @@
     #endif
 #endif
 
-#define VR_SUPPORT
+//#define VR_SUPPORT
 // TODO: fix depth precision
 // TODO: fix water surface rendering
 // TODO: fix clipping
@@ -698,8 +698,8 @@ mat4 convToMat4(const vr::HmdMatrix34_t &m) {
                 m.m[0][2], m.m[1][2], m.m[2][2], 0.0f,
                 m.m[0][3], m.m[1][3], m.m[2][3], 1.0f);
 }
-//utility functions for reading digital state( from openvr sample)
-//utility function for reading digital state
+//utility functions for reading digital states( from openvr sample)
+//
 bool GetDigitalActionState(vr::VRActionHandle_t action, vr::VRInputValueHandle_t *pDevicePath = nullptr)
 {
     vr::InputDigitalActionData_t actionData;
@@ -805,7 +805,7 @@ void vrUpdateInput() {
     Input::hmd.state[cRoll]      = GetDigitalActionState(VRcRoll);
     Input::hmd.state[cStart]     = GetDigitalActionState(VRcStart);
     Input::hmd.state[cInventory] = GetDigitalActionState(VRcInventory);
-    //
+    
     if (GetDigitalActionFallingEdge(VRcToggle)) {
         Input::hmd.rotationState =  !Input::hmd.rotationState;
         Input::hmd.rotationMode = Input::hmd.rotationState;

--- a/src/platform/win/main.cpp
+++ b/src/platform/win/main.cpp
@@ -14,7 +14,7 @@
     #endif
 #endif
 
-#define VR_SUPPORT
+//#define VR_SUPPORT
 // TODO: fix depth precision
 // TODO: fix water surface rendering
 // TODO: fix clipping


### PR DESCRIPTION
Trying to add snap rotation to the VR controls. Managed to get it so that the HMD camera will be directly affected by Lara's head animation, but now the head tracking is no longer 1:1 with Lara's model. Any ideas on what might be the cause of this? 