### PR TITLE
Stereoscopy changes for 3DS builds

### DIFF
--- a/src/camera.h
+++ b/src/camera.h
@@ -21,6 +21,11 @@
 #define CAM_LOOK_ANGLE_XMIN  (-75.0f * DEG2RAD)
 #define CAM_LOOK_ANGLE_Y     ( 80.0f * DEG2RAD)
 
+#ifdef _OS_3DS
+    #define CAM_OFFSET_FOLLOW    (1024.0f + 512.0f + 256.0f)
+    #define CAM_FOCAL_LENGTH     512.0f
+#endif
+
 struct Camera : ICamera {
     IGame      *game;
     TR::Level  *level;
@@ -552,6 +557,10 @@ struct Camera : ICamera {
         fov   = firstPerson ? 90.0f : 65.0f;
         znear = firstPerson ? 16.0f : 32.0f;
         zfar  = 45.0f * 1024.0f;
+
+        #ifdef _OS_3DS
+            fov   = firstPerson ? 55.0f : 55.0f;
+        #endif
 
         #ifdef _OS_PSP
             znear = 256.0f;

--- a/src/camera.h
+++ b/src/camera.h
@@ -520,7 +520,11 @@ struct Camera : ICamera {
                 Core::mViewInv.setPos(Core::mViewInv.getPos() + vec3(0.0f, sinf(shake * PI * 7) * shake * 48.0f, 0.0f));
 
             if (Core::settings.detail.stereo == Core::Settings::STEREO_SBS || Core::settings.detail.stereo == Core::Settings::STEREO_ANAGLYPH)
-                Core::mViewInv.setPos(Core::mViewInv.getPos() + Core::mViewInv.right().xyz() * (Core::eye * CAM_EYE_SEPARATION) );
+                #ifdef _OS_3DS
+                    Core::mViewInv.setPos(Core::mViewInv.getPos() + Core::mViewInv.right().xyz() * (Core::eye * CAM_EYE_SEPARATION / (firstPerson ? 8.0f : 1.0f) ) );
+                #else
+					Core::mViewInv.setPos(Core::mViewInv.getPos() + Core::mViewInv.right().xyz() * (Core::eye * CAM_EYE_SEPARATION) );
+                #endif
 
             if (reflectPlane) {
                 Core::mViewInv = mat4(*reflectPlane) * Core::mViewInv;
@@ -559,7 +563,7 @@ struct Camera : ICamera {
         zfar  = 45.0f * 1024.0f;
 
         #ifdef _OS_3DS
-            fov   = firstPerson ? 55.0f : 55.0f;
+            fov   = firstPerson ? 65.0f : 55.0f;
         #endif
 
         #ifdef _OS_PSP

--- a/src/level.h
+++ b/src/level.h
@@ -2942,7 +2942,13 @@ struct Level : IGame {
 
     void renderPrepare() {
         #ifdef _OS_3DS
-            Core::settings.detail.stereo = osGet3DSliderState() > 0.0f ? Core::Settings::STEREO_SBS : Core::Settings::STEREO_OFF;
+            if (osGet3DSliderState() > 0.0f && !inventory->video) {
+                Core::settings.detail.stereo = Core::Settings::STEREO_SBS;
+                gfxSet3D(true);
+            } else {
+                Core::settings.detail.stereo = Core::Settings::STEREO_OFF;
+                gfxSet3D(false);
+            }
         #endif
 
         if (Core::settings.detail.stereo == Core::Settings::STEREO_ANAGLYPH) {

--- a/src/level.h
+++ b/src/level.h
@@ -3002,7 +3002,7 @@ struct Level : IGame {
         int texIndex = eye <= 0 ? 0 : 1;
 
         #ifdef _OS_3DS
-            Core::eye *= osGet3DSliderState();
+            Core::eye *= osGet3DSliderState() * 3.25;
 
             GAPI::curTarget = GAPI::defTarget[texIndex];
 

--- a/src/level.h
+++ b/src/level.h
@@ -3002,7 +3002,7 @@ struct Level : IGame {
         int texIndex = eye <= 0 ? 0 : 1;
 
         #ifdef _OS_3DS
-            Core::eye *= osGet3DSliderState() * 3.25;
+            Core::eye *= osGet3DSliderState() * 3.25f;
 
             GAPI::curTarget = GAPI::defTarget[texIndex];
 


### PR DESCRIPTION
Several minor changes here:
- the normal FOV is reduced to 55 degrees (like the PSX game)
- FPS FOV is reduced to 65 degrees
- 3D slider value multiplied by 3.25 for deeper 3D (divided by 8 in FPS mode)
- focal length reduced to 512 from 1536 to make things close to the camera sink in rather than pop out (divided by 8 in FPS mode)