### PR TITLE
Fix renderbar position on save game screen

### DIFF
--- a/src/inventory.h
+++ b/src/inventory.h
@@ -2025,7 +2025,7 @@ struct Inventory {
         if (page == PAGE_SAVEGAME) {
             UI::renderBar(CTEX_OPTION, vec2(UI::width / 2 - 120, 240 - 14), vec2(240, LINE_HEIGHT - 6), 1.0f, 0x802288FF, 0, 0, 0);
             UI::textOut(vec2(0, 240), pageTitle[page], UI::aCenter, UI::width);
-            UI::renderBar(CTEX_OPTION, vec2(slot + UI::width / 2 - 48, 240 + 24 - 16), vec2(48, 18), 1.0f, 0xFFD8377C, 0);
+            UI::renderBar(CTEX_OPTION, vec2(-slot * 48 + UI::width / 2, 240 + 24 - 16), vec2(48, 18), 1.0f, 0xFFD8377C, 0);
             UI::textOut(vec2(UI::width / 2 - 48, 240 + 24), STR_YES, UI::aCenter, 48);
             UI::textOut(vec2(UI::width / 2, 240 + 24), STR_NO, UI::aCenter, 48);
             return;


### PR DESCRIPTION
I don't know if this is the correct way to resolve this, but currently the render bar which highlights "YES" and "NO" on the save game screen (when you Action a save crystal) doesn't move correctly. The value used to determine how far to move the renderbar, `slot`, seems to be `1` if YES and `0` if NO. Here I'm swapping these with `-slot` and multiplying by `48` (the width of the YES/NO text).

The end result looks correct but this solution may be janky, feel free to reject this PR and fix it properly.