### PR TITLE
Fix SDL2 with GLES2 compilation

### DIFF
--- a/src/gapi/gl.h
+++ b/src/gapi/gl.h
@@ -66,7 +66,6 @@
     #include <SDL2/SDL.h>
 
     #if defined(_GAPI_GLES)
-        #define GL_GLEXT_PROTOTYPES 1
         #include <SDL2/SDL_opengles2.h>
         #include <SDL2/SDL_opengles2_gl2ext.h>
 
@@ -94,6 +93,8 @@
         #define GL_TEXTURE_WRAP_R       0
         #define GL_DEPTH_STENCIL        GL_DEPTH_STENCIL_OES
         #define GL_UNSIGNED_INT_24_8    GL_UNSIGNED_INT_24_8_OES
+	//We need this on GLES2, too.
+        #define GL_TEXTURE_MAX_LEVEL     GL_TEXTURE_MAX_LEVEL_APPLE
 
         #define glTexImage3D(...) 0
         #ifndef GL_TEXTURE_3D // WUUUUUT!?
@@ -108,7 +109,6 @@
         #define glGetProgramBinary(...)
         #define glProgramBinary(...)
     #else
-        #define GL_GLEXT_PROTOTYPES 1
         #include <SDL2/SDL_opengl.h>
         #include <SDL2/SDL_opengl_glext.h>
     #endif
@@ -1483,7 +1483,9 @@ namespace GAPI {
             if (count) {
                 #ifdef _OS_ANDROID
                     glInvalidateFramebuffer(GL_FRAMEBUFFER, count, discard);
-                #else
+                #elif !defined(__SDL2__)
+                    /* SDL2 typically uses MESA which does not have glDiscardFramebufferEXT() implemented
+                       for some drivers, like Gallium VC4. */ 
                     glDiscardFramebufferEXT(GL_FRAMEBUFFER, count, discard);
                 #endif
             }


### PR DESCRIPTION
With recent changes, building the SDL2 platform with GLES2 was not possible anymore.
I will now explain these changes:

-Do NOT define GL_GLEXT_PROTOTYPES, since it can expose function prototypes that are not implemented. If a not-implemented function has its prototype exposed, the program will build but will not link.

-Do NOT call glDiscardFramebufferEXT() when we are building for the SDL2 platform, because some MESA Gallium drivers (like VC4 on the Raspberry Pi) does not implement this extension, and merely having the glDiscardFramebufferEXT() call in the code, even if it is not supported, causes a building error because the function is not implemented.