### PR TITLE
Properly fix GLES2 on SDL2, and add GLES3 support on SDL2 platform.

### DIFF
--- a/src/platform/sdl2/build.sh
+++ b/src/platform/sdl2/build.sh
@@ -1,7 +1,10 @@
 set -e
 
-# Use this compilation line to build SDL2/GLES version
-g++ -DSDL2_GLES -std=c++11 `sdl2-config --cflags` -O3 -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections -DNDEBUG -D__SDL2__ main.cpp ../../libs/stb_vorbis/stb_vorbis.c ../../libs/minimp3/minimp3.cpp ../../libs/tinf/tinflate.c -I../../ -o OpenLara `sdl2-config --libs` -lGLESv2 -lEGL -lm -lrt -lpthread -lasound -ludev
+# Use this compilation line to build SDL2/GLES version, GLES2.
+g++ -DSDL2_GLES -D_GAPI_GLES2 -std=c++11 `sdl2-config --cflags` -O3 -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections -DNDEBUG -D__SDL2__ main.cpp ../../libs/stb_vorbis/stb_vorbis.c ../../libs/minimp3/minimp3.cpp ../../libs/tinf/tinflate.c -I../../ -o OpenLara `sdl2-config --libs` -lGLESv2 -lEGL -lm -lrt -lpthread -lasound -ludev
+
+# Use this compilation line to build SDL2/GLES version, GLES3, which is an extension to GLES2, so we use -lGLESv2, too.
+#g++ -DSDL2_GLES -std=c++11 `sdl2-config --cflags` -O3 -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections -DNDEBUG -D__SDL2__ main.cpp ../../libs/stb_vorbis/stb_vorbis.c ../../libs/minimp3/minimp3.cpp ../../libs/tinf/tinflate.c -I../../ -o OpenLara `sdl2-config --libs` -lGLESv2 -lEGL -lm -lrt -lpthread -lasound -ludev
 
 # Use this compilation line to build SDL2/OpenGL version
 #g++ -std=c++11 `sdl2-config --cflags` -O3 -fno-exceptions -fno-rtti -ffunction-sections -fdata-sections -Wl,--gc-sections -DNDEBUG -D__SDL2__ main.cpp ../../libs/stb_vorbis/stb_vorbis.c ../../libs/minimp3/minimp3.cpp ../../libs/tinf/tinflate.c -I../../ -o OpenLara `sdl2-config --libs` -lGL -lm -lrt -lpthread -lasound -ludev


### PR DESCRIPTION
I removed the glDiscardFramebuffer() call because I really no see use for it, look:
-In GLES1, it is just not supported.
-In GLES2, we can not count on it to be implemented as its missing on some MESA GLES2 drivers like Gallium VC4 (Raspberry Pi 1, 2 and 3).
-In GLES3 and Android, we have glInvalidateBuffer().
So, there is no place for glDiscardFramebuffer() unless some closed-source driver implements it, which I am not sure at all.