### PR TITLE
Fix human enemy centre to head length value (should be 0)

### DIFF
--- a/src/enemy.h
+++ b/src/enemy.h
@@ -2550,7 +2550,7 @@ struct Human : Enemy {
     int jointGun;
     int animDeath;
 
-    Human(IGame *game, int entity, float health) : Enemy(game, entity, health, 100, 375.0f, 1.0f), animDeath(-1) {
+    Human(IGame *game, int entity, float health) : Enemy(game, entity, health, 100, 0.0f, 1.0f), animDeath(-1) {
         jointGun   = 0;
         jointChest = 7;
         jointHead  = 8;


### PR DESCRIPTION
Fixes a bug where the human enemies had their center to head value set the same as the wolf, resulting in them losing track of Lara very easily. This should more closely mimic original behaviour.