### PR TITLE
Fix portal scissor glitches

### DIFF
--- a/src/level.h
+++ b/src/level.h
@@ -1928,6 +1928,13 @@ struct Level : IGame {
         s.z -= s.x;
         s.w -= s.y;
 
+        // Use the viewport rect if one of the dimensions is the same size
+        // as the viewport. This may fix clipping bugs while still allowing
+        // impossible geometry tricks.
+        if (s.z - s.x >= vp.z - vp.x || s.w - s.y >= vp.w - vp.y) {
+           return vp;
+        }
+
         return s;
     }
 


### PR DESCRIPTION
This includes code to modify the getPortalRect function where if the overall width or height exceededs the bounds of the viewport, it will simply expand to the overall viewport. This should fix some glitches with room geometry which overlaps outside of its bounds like in the screenshot below, while still allowing overlapping rooms like those outside of Lara's Home to be scissor clipped correctly.
![scissor_glitch](https://user-images.githubusercontent.com/12756047/93806754-8dc82780-fc41-11ea-8bff-ea0f1d209190.png)
