### PR TITLE
Fix for jump timing and buffering input during recover state

### DIFF
--- a/src/lara.h
+++ b/src/lara.h
@@ -4684,7 +4684,7 @@ struct Lara : Character {
             if (animIndex == ANIM_RUN_START) {
                 canJump = false;
             } else if (animIndex == ANIM_RUN) {
-                if (frameIndex == 4) {
+                if (frameIndex == 2) {
                     canJump = true;
                 }
             } else {
@@ -4700,6 +4700,8 @@ struct Lara : Character {
     }
     
     S_HANDLER(STATE_STOP) {
+        targetState = STATE_STOP;
+
         if (checkDeath()) {
             targetState = STATE_DEATH;
             return;

--- a/src/lara.h
+++ b/src/lara.h
@@ -4684,7 +4684,7 @@ struct Lara : Character {
             if (animIndex == ANIM_RUN_START) {
                 canJump = false;
             } else if (animIndex == ANIM_RUN) {
-                if (frameIndex == 2) {
+                if (frameIndex == 4 || ((level->version & TR::VER_VERSION) == TR::VER_TR1)) {
                     canJump = true;
                 }
             } else {
@@ -4700,8 +4700,6 @@ struct Lara : Character {
     }
     
     S_HANDLER(STATE_STOP) {
-        targetState = STATE_STOP;
-
         if (checkDeath()) {
             targetState = STATE_DEATH;
             return;
@@ -4710,6 +4708,8 @@ struct Lara : Character {
         if (s_checkRoll()) {
             return;
         }
+
+		targetState = STATE_STOP;
 
         if ((input & (FORTH | ACTION)) == (FORTH | ACTION)) {
             c_angle(ANGLE_0);

--- a/src/lara.h
+++ b/src/lara.h
@@ -4709,7 +4709,7 @@ struct Lara : Character {
             return;
         }
 
-		targetState = STATE_STOP;
+        targetState = STATE_STOP;
 
         if ((input & (FORTH | ACTION)) == (FORTH | ACTION)) {
             c_angle(ANGLE_0);


### PR DESCRIPTION
Make it so that a jump from the running state occurs on frame 2 rather than 4 to allow running jumps to be performed correctly. Fix inputs being buffered during recover animations.