### PR TITLE
SDL backend: enable vsync to prevent tearing.

### DIFF
--- a/src/platform/sdl2/main.cpp
+++ b/src/platform/sdl2/main.cpp
@@ -493,7 +493,7 @@ int main(int argc, char **argv) {
     Core::height = h;
 
     SDL_GLContext context = SDL_GL_CreateContext(sdl_window);
-    SDL_GL_SetSwapInterval(0);
+    SDL_GL_SetSwapInterval(1);
 
     sdl_renderer = SDL_CreateRenderer(sdl_window, -1,
 	  SDL_RENDERER_ACCELERATED | SDL_RENDERER_TARGETTEXTURE);


### PR DESCRIPTION
I hadn't noticed this until now because SDL2 on KMSDRM wasn't able to do asynchronous pageflips, but since I implemented them recently, tearing in OpenLara on SDL2 on KMSDRM became apparent... So it was time to correct it.