### PR TITLE
SDL2: proper fix for the vsync setting.

### DIFF
--- a/src/gapi/gl.h
+++ b/src/gapi/gl.h
@@ -1597,6 +1597,8 @@ namespace GAPI {
             if (wglSwapIntervalEXT) wglSwapIntervalEXT(enable ? 1 : 0);
         #elif _OS_LINUX
             if (glXSwapIntervalSGI) glXSwapIntervalSGI(enable ? 1 : 0);
+        #elif defined(__SDL2__)
+            SDL_GL_SetSwapInterval(enable ? 1 : 0);
         #elif defined(_OS_RPI) || defined(_OS_CLOVER) || defined(_OS_SWITCH)
             eglSwapInterval(display, enable ? 1 : 0);
         #endif

--- a/src/platform/sdl2/main.cpp
+++ b/src/platform/sdl2/main.cpp
@@ -88,7 +88,6 @@ int sdl_numjoysticks, sdl_numcontrollers;
 SDL_Joystick *sdl_joysticks[MAX_JOYS];
 SDL_GameController *sdl_controllers[MAX_JOYS];
 SDL_Window *sdl_window;
-SDL_Renderer *sdl_renderer;
 SDL_DisplayMode sdl_displaymode;
 
 bool fullscreen;
@@ -493,10 +492,6 @@ int main(int argc, char **argv) {
     Core::height = h;
 
     SDL_GLContext context = SDL_GL_CreateContext(sdl_window);
-    SDL_GL_SetSwapInterval(1);
-
-    sdl_renderer = SDL_CreateRenderer(sdl_window, -1,
-	  SDL_RENDERER_ACCELERATED | SDL_RENDERER_TARGETTEXTURE);
 
     SDL_ShowCursor(SDL_DISABLE);
 
@@ -538,7 +533,6 @@ int main(int argc, char **argv) {
     sndFree();
     Game::deinit();
 
-    SDL_DestroyRenderer(sdl_renderer);
     SDL_DestroyWindow(sdl_window);
     SDL_Quit();
 


### PR DESCRIPTION
Proper fix for vsync configuration on SDL2.

Yesterday's fix was fixed on wrong asumption, it's now done the intended way and on the right place.
I have also removed the redundant SDL_Renderer which wasn't used at all and interfered with the vsync configuration.

Please merge, thanks! 