### PR TITLE
Fix to "look" input code so it uses the correct gamepad index

### DIFF
--- a/src/camera.h
+++ b/src/camera.h
@@ -418,7 +418,7 @@ struct Camera : ICamera {
                 if (mode == MODE_LOOK) {
                     float d = 3.0f * Core::deltaTime;
 
-                    vec2 L = Input::joy[cameraIndex].L;
+                    vec2 L = Input::joy[Core::settings.controls[cameraIndex].joyIndex].L;
                     L = L.normal() * max(0.0f, L.length() - INPUT_JOY_DZ_STICK) / (1.0f - INPUT_JOY_DZ_STICK);
 
                     lookAngle.x += L.y * d;


### PR DESCRIPTION
This fixes the bug where if you're player 1 but have selected gamepad #2 it would still try to read joystick of gamepad #1 for looking around.