### PR TITLE
fix build, simplify imports on macOS 11 and 10.15

### DIFF
--- a/src/gapi/gl.h
+++ b/src/gapi/gl.h
@@ -271,32 +271,11 @@
         //#define GL_TEXTURE_COMPARE_FUNC     GL_TEXTURE_COMPARE_FUNC_EXT
         //#define GL_COMPARE_REF_TO_TEXTURE   GL_COMPARE_REF_TO_TEXTURE_EXT
     #else
-        #include <Carbon/Carbon.h>
         #include <AudioToolbox/AudioQueue.h>
-        #include <OpenGL/OpenGL.h>
-        #include <OpenGL/gl.h>
-        #include <OpenGL/glext.h>
-        #include <AGL/agl.h>
+        #include <OpenGL/gl3.h>
+        #include <OpenGL/gl3ext.h>
 
-        #define GL_RG                       0x8227
-        #define GL_RG16F                    0x822F
-        #define GL_RG32F                    0x8230
-        #define GL_RGBA16F                  0x881A
-        #define GL_RGBA32F                  0x8814
-        #define GL_HALF_FLOAT               0x140B
-
-        #define GL_RGB565                   GL_RGBA
-        #define GL_TEXTURE_COMPARE_MODE     0x884C
-        #define GL_TEXTURE_COMPARE_FUNC     0x884D
-        #define GL_COMPARE_REF_TO_TEXTURE   0x884E
-
-        #define glGenVertexArrays    glGenVertexArraysAPPLE
-        #define glDeleteVertexArrays glDeleteVertexArraysAPPLE
-        #define glBindVertexArray    glBindVertexArrayAPPLE
-
-        #define GL_PROGRAM_BINARY_LENGTH 0
-        #define glGetProgramBinary(...)  0
-        #define glProgramBinary(...)     0
+        #define GL_LUMINANCE 0x1909
     #endif
 #elif _OS_WEB
     #include <emscripten/emscripten.h>


### PR DESCRIPTION
fix build on macOS 11 and 10.15, including on Apple silicon

There was a build error on macOS due to use of undeclared identifiers
glGetStringi and GL_NUM_EXTENSIONS. Those identifiers are declared in
OpenGL 3.0.

Switch from importing OpenGL/{gl.h,glext.h} to OpenGL/{gl3.h,gl3ext.h},
which fixes the problem. It also allows removing many OpenGL 3+ #defines,
though we do need to #define GL_LUMINANCE as was done in OpenGL/gl.h.
(It's also possible to keep the OpenGL/gl.h import, but it seems worse
to be importing both.)

Also remove #includes of Carbon/Carbon.h, OpenGL/OpenGL.h, AGL/agl.h,
since they don't seem to be needed.

Tested on macOS 11.4 (Big Sur) with Xcode 12.5.1 on Apple silicon,
and on macOS 10.15.7 (Catalina) with Xcode 12.4 on an Intel-based Mac.
(Hopefully this doesn't break older macOS platforms,
but unfortunately I can't test that easily.)

Fixes #354.