### PR TITLE
restore high graphics detail on macOS

### DIFF
--- a/src/gapi/gl.h
+++ b/src/gapi/gl.h
@@ -274,6 +274,14 @@
         #include <AudioToolbox/AudioQueue.h>
         #include <OpenGL/gl3.h>
         #include <OpenGL/gl3ext.h>
+        #include <OpenGL/glext.h>
+
+        // In compatibility mode, macOS only provides OpenGL 2.1 (no VAO), but it does
+        // support the Apple-specific VAO extension which is older and in all relevant
+        // parts 100% compatible. So use those functions instead.
+        #define glGenVertexArrays    glGenVertexArraysAPPLE
+        #define glDeleteVertexArrays glDeleteVertexArraysAPPLE
+        #define glBindVertexArray    glBindVertexArrayAPPLE
 
         #define GL_LUMINANCE 0x1909
     #endif
@@ -1135,7 +1143,7 @@ namespace GAPI {
 
 
     bool extSupport(const char *str) {
-        #if !defined(_GAPI_GLES2) 
+        #if !defined(_GAPI_GLES2) && !_OS_MAC
         if (glGetStringi != NULL) {
             GLint count = 0;
             glGetIntegerv(GL_NUM_EXTENSIONS, &count); 


### PR DESCRIPTION
The macOS platform currently creates and uses an OpenGL 2.1 profile,
but it can still achieve high graphics detail in theory. In practice,
that ability regressed.

Prior to PR #355, extSupport made use of an undeclared glGetStringi,
a build error. That was fixed by importing a header that declared it.
That caused extSupport to start reporting false for any input. This
is due to the (glGetStringi != NULL) check not having the intended
effect on macOS, as reported in #357.

As long as OpenGL 2.1 profile is used, extSupport can't make use
of the glGetStringi + GL_NUM_EXTENSIONS code path, so explicitly
disable it on macOS for now via a preprocessor guard.

Another regression introduced by #355 is the removal of redefines
of glGenVertexArrays, glDeleteVertexArrays, glBindVertexArray with
Apple-specific versions, needed to get VAO alongside OpenGL 2.1.
So, bring this back, along with the comment justifying why they're
needed (as was done before 6e6ed3b2d0e8c0c9af83d5cb9653793ca76047f4).
Import OpenGL/glext.h to get definitions of those APPLE functions.

With these changes, high graphics detail settings are available on
macOS once again.

Fixes #356.
Updates #357.