### PR TITLE
Fix Lara drawing guns when exiting water [GBA]

### DIFF
--- a/src/fixed/lara.h
+++ b/src/fixed/lara.h
@@ -1707,6 +1707,7 @@ struct Lara : ItemObj
         //game->waterDrop(pos, 128.0f, 0.2f);
 
         animSet(ANIM_WATER_OUT, true);
+        setWeaponState(WEAPON_STATE_BUSY);
 
         waterState = WATER_STATE_ABOVE;
         goalState = STATE_STOP;


### PR DESCRIPTION
Fix minor bug with Lara being able to draw weapons immediately after trying to exit a body of water