### PR TITLE
Apply basis to arms when pistols/uzis are ready [GBA]

### DIFF
--- a/src/fixed/lara.h
+++ b/src/fixed/lara.h
@@ -3461,7 +3461,7 @@ struct Lara : ItemObj
 
             arm->animIndex = anim + level.models[params.animType].animIndex;
             arm->frameIndex = frame;
-            arm->useBasis = (anim == ANIM_PISTOLS_AIM && frame) || (anim == ANIM_PISTOLS_FIRE);
+            arm->useBasis = (anim == ANIM_PISTOLS_AIM) || (anim == ANIM_PISTOLS_FIRE);
         }
     }
 


### PR DESCRIPTION
Although it may be less realistic, applying basis transform to the elbows whenever the pistols/uzis are out is more accurate to the behaviour of the original game. Makes the arms wobble less when running.