### PR TITLE
Lara combat tracking fixes [GBA]

### DIFF
--- a/src/fixed/lara.h
+++ b/src/fixed/lara.h
@@ -2812,7 +2812,7 @@ struct Lara : ItemObj
                 if (R.aim && L.aim) {
                     H.x = T.x = aX >> 2;
                     H.y = T.y = aY >> 2;
-                } else if (R.aim ^ L.aim) {
+                } else {
                     H.x = T.x = aX >> 1;
                     H.y = T.y = aY >> 1;
                 }
@@ -3636,7 +3636,7 @@ struct Lara : ItemObj
                 extraL->armR.aim = extraL->armL.aim = true;
             } else {
                 extraL->armR.aim = extraL->armR.aim && (abs(angleAim.x) <= params.armX) && (angleAim.y >=  params.armMinY) && (angleAim.y <=  params.armMaxY);
-                extraL->armL.aim = extraL->armR.aim && (abs(angleAim.x) <= params.armX) && (angleAim.y >= -params.armMaxY) && (angleAim.y <= -params.armMinY);
+                extraL->armL.aim = extraL->armL.aim && (abs(angleAim.x) <= params.armX) && (angleAim.y >= -params.armMaxY) && (angleAim.y <= -params.armMinY);
             }
         } else {
             extraL->armR.aim = extraL->armL.aim = false;


### PR DESCRIPTION
Fixes Lara losing tracking of enemies in her left tangent when she should still be tracking them, and restoring Lara's torso and head rotations when a target has been properly lost.