### PR TITLE
Fix crash when loading with picked up items.

### DIFF
--- a/src/ui.h
+++ b/src/ui.h
@@ -545,6 +545,7 @@ namespace UI {
         showHelp = false;
         helpTipTime = 5.0f;
         hintTime = subsTime = 0.0f;
+        pickups.clear();
     }
 
     void deinit() {


### PR DESCRIPTION
If picked up items were still being displayed in the corner of the screen when loading a save or a new level it would crash by trying to animate an item no longer available.