### PR TITLE
Restored PSP build, added fog to it

### DIFF
--- a/src/level.h
+++ b/src/level.h
@@ -3489,8 +3489,11 @@ struct Level : IGame {
         short4 oldViewport = Core::viewportDef;
 
         setDefaultTarget(eye, view, false);
-
-        Core::setTarget(NULL, NULL, RT_CLEAR_DEPTH | RT_STORE_COLOR);
+	#ifdef FFP //fixme: psp framebuffer error?
+		Core::setTarget(NULL, NULL, RT_CLEAR_DEPTH | RT_CLEAR_COLOR | RT_STORE_COLOR);
+	#else
+		Core::setTarget(NULL, NULL, RT_CLEAR_DEPTH | RT_STORE_COLOR);
+	#endif
 
         float aspect = setViewport(view, eye);
 

--- a/src/sound.h
+++ b/src/sound.h
@@ -653,7 +653,7 @@ namespace Sound {
         }
 
         virtual int decode(Frame *frames, int count) {
-        #if _OS_PSV // TODO crash
+        #if defined(_OS_PSV) || defined(_OS_PSP) // TODO crash
             memset(frames, 0, count * sizeof(Frame));
             return count;
         #endif

--- a/src/texture.h
+++ b/src/texture.h
@@ -17,11 +17,11 @@ struct Texture : GAPI::Texture {
         #elif defined(_GAPI_GU)
             Tile4 *tiles;
             CLUT  *cluts;
-
+		// TODO: PSP depth ??
             Texture(Tile4 *tiles, int tilesCount, CLUT *cluts, int clutsCount) : GAPI::Texture(256, 256, 1, OPT_PROXY) {
                 #ifdef EDRAM_TEX
-                    this->tiles = (TR::Tile4*)GAPI::allocEDRAM(tilesCount * sizeof(tiles[0]));
-                    this->cluts =  (TR::CLUT*)GAPI::allocEDRAM(clutsCount * sizeof(cluts[0]));
+                    this->tiles = (Tile4*)GAPI::allocEDRAM(tilesCount * sizeof(tiles[0]));
+                    this->cluts =  (CLUT*)GAPI::allocEDRAM(clutsCount * sizeof(cluts[0]));
                     memcpy(this->cluts, cluts, clutsCount * sizeof(cluts[0]));
                     #ifdef TEX_SWIZZLE
                         for (int i = 0; i < tilesCount; i++)

--- a/src/utils.h
+++ b/src/utils.h
@@ -2047,6 +2047,37 @@ public:
         strcpy(path, contentDir);
         readDirectory(path);
     }
+#elif _OS_PSP  //vita isnt called "psp2" by coincidence
+//dunno if this is used (?)
+    static void readDirectory(char* path) {
+        SceUID dd = sceIoDopen(path);
+
+        size_t len = strlen(path);
+
+        SceIoDirent entry;
+        while (sceIoDread(dd, &entry) > 0)
+        {
+            strcat(path, entry.d_name);
+
+            if (FIO_S_ISDIR(entry.d_stat.st_mode))
+            {
+                strcat(path, "/");
+                readDirectory(path);
+            } else {
+                fileList.push(StrUtils::copy(path + strlen(contentDir)));
+            }
+
+            path[len] = 0;
+        }
+
+        sceIoClose(dd);
+    }
+
+    static void readFileList() {
+        char path[255];
+        strcpy(path, contentDir);
+        readDirectory(path);
+    }  
 #else
     static void readFileList() {};
 #endif


### PR DESCRIPTION
I've managed to restore the PSP build by quick-fixing the following: 
- inv rendering errors (frames were not updating)
- sound crash (same as Vita?)
- viewport/scissor methods
- Added fog by looking at 3DS port.

The game still crashes loading some specific levels (bad vertex address on PPSSPP) or at random loading of assets in-game (on real hardware); but it compiles and works. Shadows were not restored.