### PR TITLE
analogue stick fix for raspberry pi

### DIFF
--- a/src/platform/rpi/main.cpp
+++ b/src/platform/rpi/main.cpp
@@ -359,11 +359,13 @@ void inputFree() {
 }
 
 #define JOY_DEAD_ZONE_STICK      8192
+#define JOY_CENTRE              32768
 
 float joyAxisValue(int value) {
+    value -= JOY_CENTRE;
     if (value > -JOY_DEAD_ZONE_STICK && value < JOY_DEAD_ZONE_STICK)
         return 0.0f;
-    return value / 32767.0f;
+    return value / 32768.0f;
 }
 
 float joyTrigger(int value) {

--- a/src/platform/rpi/main.cpp
+++ b/src/platform/rpi/main.cpp
@@ -197,6 +197,7 @@ int inputDevices[MAX_INPUT_DEVICES];
 udev *udevObj;
 udev_monitor *udevMon;
 int udevMon_fd;
+int joy_centre;
 
 vec2 joyL, joyR;
 
@@ -347,6 +348,10 @@ bool inputInit() {
     }
     udev_enumerate_unref(e);
 
+    const char *temp = getenv("JOY_CENTRE");
+    if (temp && (joy_centre = atoi(temp)))
+        LOG("input: joy centred at %d\n", joy_centre);
+
     return true;
 }
 
@@ -362,7 +367,7 @@ void inputFree() {
 #define JOY_CENTRE              32768
 
 float joyAxisValue(int value) {
-    value -= JOY_CENTRE;
+    value -= joy_centre ? joy_centre : JOY_CENTRE;
     if (value > -JOY_DEAD_ZONE_STICK && value < JOY_DEAD_ZONE_STICK)
         return 0.0f;
     return value / 32768.0f;


### PR DESCRIPTION
Originally reported as issue #462. It appears it boils down to how evdev reports absolute stick input that requires calibrating. It has been made possible to override the fix setting the `JOY_CENTRE` variable. The fix is specific to raspberry pi platform, untested elsewhere.