### PR TITLE
Fix segfault on Linux when files aren't found

### DIFF
--- a/src/platform/nix/main.cpp
+++ b/src/platform/nix/main.cpp
@@ -323,6 +323,7 @@ void joyUpdate() {
 // filesystem
 #define MAX_FILES 4096
 char* gFiles[MAX_FILES];
+const char* gEmpty = "";
 int32 gFilesCount;
 
 void addDir(char* path)
@@ -386,7 +387,7 @@ const char* osFixFileName(const char* fileName)
             return gFiles[i];
         }
     }
-    return NULL;
+    return gEmpty;
 }
 
 // system

--- a/src/utils.h
+++ b/src/utils.h
@@ -1683,7 +1683,7 @@ extern void osWriteSlot  (Stream *stream);
 
 #ifdef _OS_LINUX
 extern const char* osFixFileName(const char* fileName);
-#endif;
+#endif
 
 #ifdef _OS_WEB
 extern void osDownload   (Stream *stream);


### PR DESCRIPTION
When the game is started with missing data files on Linux, osFixFileName will return a null pointer, which gets dereferenced in Stream::openFile, which causes a segfault, and no helpful error message is printed. With this commit the game will instead exit cleanly so the user can read the file error in the log.