### PR TITLE
Add Linux automated build and release.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,35 @@
+name: Continuous build and release
+on: [push, pull_request]
+
+jobs:
+  nix_x86_64:
+    name: Linux x86_64
+    runs-on: ubuntu-latest
+    container: ubuntu:20.04
+    env:
+      RELEASE_DIRECTORY: /tmp/OpenLara_Release
+      RELEASE_FILE_README: /tmp/OpenLara_Release/readme.txt
+    steps:
+      - name: Retrieve sources
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          apt update
+          DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y clang libgl-dev libpulse-dev libx11-dev zip
+      - name: Build
+        run: ./build.sh
+        working-directory: src/platform/nix
+      - name: Create archive
+        run: |
+          mkdir -p ${{ env.RELEASE_DIRECTORY }}
+          cp bin/OpenLara ${{ env.RELEASE_DIRECTORY }}
+          printf "Instructions:\n" > ${{ env.RELEASE_FILE_README }}
+          printf "STEP 1: Let's assume that you own the original game, so download and unzip (\"extract here\") these archives:\n" >> ${{ env.RELEASE_FILE_README }}
+          printf "    http://xproger.info/projects/OpenLara/files/TR1_data.7z\n" >> ${{ env.RELEASE_FILE_README }}
+          printf "    http://xproger.info/projects/OpenLara/files/TR1_audio.7z\n" >> ${{ env.RELEASE_FILE_README }}
+          printf "STEP 2: Copy the extracted folders (audio, PSXDATA, DELDATA & FMV) next to the OpenLara file\n" >> ${{ env.RELEASE_FILE_README }}
+          printf "STEP 3: Run OpenLara application and enjoy the game!\n\n" >> ${{ env.RELEASE_FILE_README }}
+          printf "YouTube: https://youtube.com/c/TimurGagiev\n" >> ${{ env.RELEASE_FILE_README }}
+          printf "Discord: https://discord.gg/EF8JaQB\n" >> ${{ env.RELEASE_FILE_README }}
+          printf "Telegram: https://t.me/openlara\n" >> ${{ env.RELEASE_FILE_README }}
+          cd ${{ env.RELEASE_DIRECTORY }} && zip OpenLara_nix.zip *

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,9 @@
 name: Continuous build and release
 on: [push, pull_request]
 
+permissions:
+  contents: write
+
 jobs:
   nix_x86_64:
     name: Linux x86_64
@@ -33,3 +36,10 @@ jobs:
           printf "Discord: https://discord.gg/EF8JaQB\n" >> ${{ env.RELEASE_FILE_README }}
           printf "Telegram: https://t.me/openlara\n" >> ${{ env.RELEASE_FILE_README }}
           cd ${{ env.RELEASE_DIRECTORY }} && zip OpenLara_nix.zip *
+      - name: Release (only when pushing to the master branch)
+        uses: softprops/action-gh-release@v1
+        if: ${{ github.ref == 'refs/heads/master' }}
+        with:
+          files: ${{ env.RELEASE_DIRECTORY }}/OpenLara_nix.zip
+          name: Continuous build
+          tag_name: continuous-build


### PR DESCRIPTION
Automatically build and package the `nix` platform (for Linux x86_64) when a pull request is opened or when a commit is pushed to the `master` branch.
If a commit is pushed to the `master` branch, the archived binary is also automatically released to a tag called `continuous-build`.

See https://github.com/RICCIARDI-Adrien/OpenLara/actions/runs/5919948724/job/16050699820 for a non-master branch push (so without release), https://github.com/RICCIARDI-Adrien/OpenLara/actions/runs/5919935315/job/16050673601 for a master branch push followed by the automatic release https://github.com/RICCIARDI-Adrien/OpenLara/releases/tag/continuous-build.