### PR TITLE
Fixed Linux error where files could not be loaded

### DIFF
--- a/src/platform/nix/main.cpp
+++ b/src/platform/nix/main.cpp
@@ -323,7 +323,6 @@ void joyUpdate() {
 // filesystem
 #define MAX_FILES 4096
 char* gFiles[MAX_FILES];
-const char* gEmpty = "";
 int32 gFilesCount;
 
 void addDir(char* path)
@@ -387,7 +386,7 @@ const char* osFixFileName(const char* fileName)
             return gFiles[i];
         }
     }
-    return gEmpty;
+    return NULL;
 }
 
 // system


### PR DESCRIPTION
The changes made in d2e363d broke the line 2131 of utils.h file: `return (name != NULL)`. It was comparing the literal address of `const char* gEmpty = ""` with NULL, causing the function `static bool exists(const char *name)` to always return true.

This problem where files could not be open is referred in issue #470.