### PR TITLE
[SDL2] Add missing SDL_QUIT event management and small bracket correction.

### DIFF
--- a/src/platform/sdl2/main.cpp
+++ b/src/platform/sdl2/main.cpp
@@ -345,6 +345,9 @@ void inputUpdate() {
 
     while (SDL_PollEvent(&event) == 1) { // while there are still events to be processed
         switch (event.type) {
+            case SDL_QUIT:
+                Core::isQuit = true;
+
             case SDL_KEYDOWN: {
                 int scancode = event.key.keysym.scancode;
                 InputKey key = codeToInputKey(scancode);
@@ -417,6 +420,7 @@ void inputUpdate() {
             case SDL_CONTROLLERDEVICEREMOVED: {
                 joyRemove(event.cdevice.which);
                 break;
+            }
 
             // Joystick reading using the old SDL Joystick interface
             case SDL_JOYBUTTONDOWN:
@@ -475,7 +479,6 @@ void inputUpdate() {
                     }
                     break;
                 }
-            }
         }
     }
 }


### PR DESCRIPTION
Without proper `SDL_QUIT` event management, Lara is left in perpetual jump state when ALT+F4 is pressed, at least on GNU/Linux + Wayland because ALT is perpetually down, and game wouldn't quit as it's supposed to do.

Also, small bracket correction in `inputUpdate()`: a closing curly bracket was missing in `case SDL_CONTROLLERDEVICEREMOVED`  and after adding it another curly bracket was not needed at the end of the function because the aforementioned `case` is properly encapsulated now.