### PR TITLE
Add command line args for window config to platform/nix.

### DIFF
--- a/src/cmdline.h
+++ b/src/cmdline.h
@@ -1,0 +1,65 @@
+#ifndef H_CMDLINE
+#define H_CMDLINE
+
+#include <string>
+#include <stdlib.h>
+
+int argLevelName(int argc, char** argv) {
+    std::string arg;
+
+    for (int i = 1; i < argc; ++i) {
+        arg = argv[i];
+
+        if ((arg.size() >= 2) && arg[0] == '-' && arg[1] == '-') continue;
+        return i;
+    }
+
+    return 0;
+}
+
+bool argWindowSize(int argc, char** argv, unsigned int* w, unsigned int* h) {
+    std::string arg = "";
+    std::string sub = "";
+
+    for (int i = 1; i < argc; ++i) {
+        arg = argv[i];
+
+        if (arg.size() > 14 && arg.substr(0, 14) == "--window-size=") {
+            sub = arg.substr(arg.find('=') + 1, arg.size());
+            break;
+        }
+    }
+
+    if (sub.empty()) return false;
+
+    size_t pos;
+    pos = sub.find("x");
+    if (pos == sub.npos) return false;
+    if (pos + 1 >= sub.size()) return false;
+
+    std::string w_str = sub.substr(0, pos);
+    std::string h_str = sub.substr(pos + 1, sub.size());
+
+    unsigned int w_tmp = atoi(w_str.c_str());
+    unsigned int h_tmp = atoi(h_str.c_str());
+    if (w_tmp == 0 || h_tmp == 0) return false;
+
+    if (w != 0) *w = w_tmp;
+    if (h != 0) *h = h_tmp;
+
+    return true;
+}
+
+bool argFullscreen(int argc, char** argv) {
+    std::string arg;
+
+    for (int i = 1; i < argc; ++i) {
+        arg = argv[i];
+
+        if (arg == "--fullscreen") return true;
+    }
+
+    return false;
+}
+
+#endif

--- a/src/platform/nix/main.cpp
+++ b/src/platform/nix/main.cpp
@@ -13,6 +13,7 @@
 #include <pulse/simple.h>
 
 #include "game.h"
+#include "cmdline.h"
 
 #define WND_TITLE       "OpenLara"
 
@@ -498,8 +499,12 @@ int main(int argc, char **argv) {
                       ButtonPressMask | ButtonReleaseMask |
                       ButtonMotionMask | PointerMotionMask;
 
+    unsigned int wnd_width = 1280;
+    unsigned int wnd_height = 720;
+    argWindowSize(argc, argv, &wnd_width, &wnd_height);
+
     Window wnd = XCreateWindow(dpy, RootWindow(dpy, vis->screen),
-                               0, 0, 1280, 720, 0,
+                               0, 0, wnd_width, wnd_height, 0,
                                vis->depth, InputOutput, vis->visual,
                                CWColormap | CWBorderPixel | CWEventMask, &attr);
     XStoreName(dpy, wnd, WND_TITLE);
@@ -511,6 +516,8 @@ int main(int argc, char **argv) {
     Atom WM_DELETE_WINDOW = XInternAtom(dpy, "WM_DELETE_WINDOW", 0);
     XSetWMProtocols(dpy, wnd, &WM_DELETE_WINDOW, 1);
 
+    if (argFullscreen(argc, argv)) toggle_fullscreen(dpy, wnd);
+
     timeval t;
     gettimeofday(&t, NULL);
     startTime = t.tv_sec;
@@ -521,7 +528,9 @@ int main(int argc, char **argv) {
 
     joyInit();
     sndInit();
-    Game::init(argc > 1 ? argv[1] : NULL);
+
+    int levelNameArg = argLevelName(argc, argv);
+    Game::init(levelNameArg > 0 ? argv[levelNameArg] : NULL);
 
     while (!Core::isQuit) {
         if (XPending(dpy)) {


### PR DESCRIPTION
Add --window-size=widthxheight and --fullscreen args to nix main.cpp using argWindowSize() and argFullscreen(). Also add argLevelName() to preserve existing level name arg behaviour.

I put the functions in a new file, src/cmdline.h in case anyone wants to add them to other platform mains.