### PR TITLE
Fix dead bats getting stuck in circling state

### DIFF
--- a/src/fixed/enemy.h
+++ b/src/fixed/enemy.h
@@ -139,9 +139,6 @@ struct Enemy : ItemObj
         tinfo.canAttack = false;
         tinfo.rotHead = 0;
 
-        if (health <= 0)
-            return;
-
         // update navigation target
         const uint16* zones = getZones();
 
@@ -151,6 +148,9 @@ struct Enemy : ItemObj
         tinfo.zoneIndexTarget = zones[tinfo.boxIndexTarget];
 
         //@TODO blocking
+
+        if (health <= 0)
+            return;
 
         if (tinfo.target->health <= 0)
         {


### PR DESCRIPTION
I noticed that bats can randomly get stuck mid air circling forever or until the corpse timer removes them. This happens because the tinfo.zoneIndex global is not updated for dead enemies, which is fine in most cases when there's no movement, but bats have gravity set. If there is an enemy with a different zoneIndex that's updated before the dead bat this condition will fail and the bat will never hit the ground:
https://github.com/XProger/OpenLara/blob/master/src/fixed/enemy.h#L548
I moved the health check a bit further down in updateTargetInfo which adds a bit of extra overhead, but it shouldn't have a significant impact if HIDE_CORPSES is set.