### PR TITLE
Fix a Heap Buffer Overflow in Enemy Pathing

### DIFF
--- a/src/enemy.h
+++ b/src/enemy.h
@@ -407,7 +407,7 @@ struct Enemy : Character {
         if (targetBox == TR::NO_BOX)
             gotoBox(target->box);
 
-        if (path && this->box != path->boxes[path->index - 1] && this->box != path->boxes[path->index])
+        if (path && (path->index == 0 || this->box != path->boxes[path->index - 1]) && this->box != path->boxes[path->index])
             targetBoxOld = TR::NO_BOX;
 
         if (zoneOld != zone)


### PR DESCRIPTION
This commit prevents an out of bounds array access in enemy.h. This access was occuring when the path->index was 0. The path->index is 0 when there is only one box in the path->box array. This occurrs when the enemy's target box is the box that it is already in. This is a valid case when an enemy is attacking a nearby creature.

The out of bounds access was occuring in an if check. The if check verifies that either the current or previous box in the path is equal to the enemy's current box. If the current enemy box is not equivialent to the box in path->box at the current or previous index, then the targetBoxOld is set to the invalid value, NO_BOX, which causes the path the regenerate.

This commit avoids the out of bounds access by avoiding checking the box at (path->index - 1) if the index is 0. This maintains the same behavior as before this commit because the out of bounds access was always accessing a garbage value not equal to the current enemy box value.