### PR TITLE
fix WIN32/ANDROID defined usage in core.h

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -33,7 +33,7 @@
     #endif
 
     #undef OS_PTHREAD_MT
-#elif WIN32
+#elif defined(_WIN32)
     #define _OS_WIN      1
     #define _GAPI_GL     1
     //#define _GAPI_D3D9   1
@@ -53,7 +53,7 @@
 
     #define INV_VIBRATION
     #define INV_QUALITY
-#elif ANDROID
+#elif defined(ANDROID)
     #define _OS_ANDROID 1
     #define _GAPI_GL    1
     #define _GAPI_GLES  1


### PR DESCRIPTION
Fixes compile under MINGW. The use of #elif WIN32 is valid under MSVC but not MINGW.

```
../../core.h:36:12: error: #elif with no expression
   36 | #elif WIN32
      |            ^
In file included from ../../core.h:812:
```

I believe the same applies to android.