### PR TITLE
[SDL2] Add fullscreen commandline parameter for desktop GL mode.

### DIFF
--- a/src/platform/sdl2/main.cpp
+++ b/src/platform/sdl2/main.cpp
@@ -489,6 +489,7 @@ void print_help(int argc, char **argv) {
            argc ? argv[0] : "OpenLara");
     puts("-d [DIRECTORY]  directory where data files are");
     puts("-l [FILE]       load a specific level file");
+    puts("-f              start in fullscreen mode (desktop GL)");
     puts("-h              print this help");
 }
 
@@ -498,7 +499,7 @@ int main(int argc, char **argv) {
     char *lvlName = nullptr;
 
     int option;
-    while ((option = getopt(argc, argv, "hl:d:")) != -1) {
+    while ((option = getopt(argc, argv, "hl:d:f")) != -1) {
         switch(option) {
             case 'h':
                 print_help(argc, argv);
@@ -508,6 +509,9 @@ int main(int argc, char **argv) {
                break;
             case 'd':
                strncpy(contentDir, optarg, 254);
+               break;
+            case 'f':
+               fullscreen = true;
                break;
             case ':':
                 printf("option %c needs a value\n", optopt);
@@ -546,14 +550,21 @@ int main(int argc, char **argv) {
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
-    /* In GLES, start in fullscreen mode using the vide mode currently in use. */
-    sdl_window = SDL_CreateWindow(WND_TITLE, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+    /* In desktop GL, start in fullscreen when instructed to do so. */
+    /* In GLES, always start in fullscreen mode using the video mode currently in use. */
 #ifdef _GAPI_GLES
-        sdl_displaymode.w, sdl_displaymode.h, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_FULLSCREEN_DESKTOP
+    sdl_window = SDL_CreateWindow(WND_TITLE, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+        sdl_displaymode.w, sdl_displaymode.h, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_FULLSCREEN_DESKTOP);
 #else
-        WIN_W, WIN_H, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN
+    if (fullscreen) {
+        sdl_window = SDL_CreateWindow(WND_TITLE, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+            sdl_displaymode.w, sdl_displaymode.h, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_FULLSCREEN_DESKTOP);
+    }
+    else {
+        sdl_window = SDL_CreateWindow(WND_TITLE, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+            WIN_W, WIN_H, SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN);
+    }
 #endif
-    ); 
  
     // We try to use the current video mode, but we inform the core of whatever mode SDL2 gave us in the end. 
     SDL_GetWindowSize(sdl_window, &w, &h);


### PR DESCRIPTION
This adds support for the "-f" commandline parameter that makes the game start in fullscreen mode when desktop GL is used (GLES is unconditionally fullscreen, as always). 