### PR TITLE
Prevent NaNs from corrupting the camera view matrix

### DIFF
--- a/src/animation.h
+++ b/src/animation.h
@@ -22,9 +22,9 @@ struct Animation {
     quat            *overrides;   // left & right arms animation frames
     int             overrideMask;
 
-    Animation() : overrides(NULL) {}
+    Animation() : level(NULL), model(NULL), anims(NULL), frameA(NULL), frameB(NULL), overrides(NULL) {}
 
-    Animation(TR::Level *level, const TR::Model *model, bool smooth = true) : level(level), model(NULL), smooth(smooth), overrides(NULL), overrideMask(0) {
+    Animation(TR::Level *level, const TR::Model *model, bool smooth = true) : level(level), model(NULL), anims(NULL), frameA(NULL), frameB(NULL), smooth(smooth), overrides(NULL), overrideMask(0) {
         setModel(model);
     }
 


### PR DESCRIPTION
This commit fixes an issue where NaNs can corrupt the camera view matrix. If a `Controller` is constructed for an `Entity` with a null `modelIndex`, the `Animation(TR::Level*, const TR::Model*, bool)` constructor will leave the `anims`, `frameA`, and `frameB` members uninitialized. If called, the function `Controller::getMatrix` will read `animation.rot` and `animation.delta` expecting that they hold valid data, returning junk data. In `Camera::update`, the result of `getMatrix` is used to update the camera view matrix `Camera::mViewInv` which can cause the view matrix to be full of NaNs.

This change guarantees that a newly constructed `Animation` struct will have either null or valid pointer members if it was constructed from null or valid `Level` and `Model`, which prevents `Controller::getMatrix` from corrupting the camera view matrix.